### PR TITLE
#30 Error categories, retry logic, and Flow extensions

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -15,8 +15,17 @@ kotlin {
 
   sourceSets {
     commonMain.dependencies {
+      api(libs.kotlinx.coroutines.core)
+
       implementation(libs.compose.resources)
       implementation(libs.compose.runtime)
+    }
+
+    commonTest.dependencies {
+      implementation(kotlin("test"))
+
+      implementation(libs.test.kotest.assertions.core)
+      implementation(libs.test.kotlinx.coroutines)
     }
   }
 }

--- a/common/src/commonMain/kotlin/com/eygraber/jellyfin/common/JellyfinErrorCategory.kt
+++ b/common/src/commonMain/kotlin/com/eygraber/jellyfin/common/JellyfinErrorCategory.kt
@@ -1,0 +1,97 @@
+package com.eygraber.jellyfin.common
+
+/**
+ * Categorization of errors that can occur during Jellyfin operations.
+ *
+ * Used to determine appropriate error messages, retry behavior, and
+ * UI feedback for different failure modes.
+ */
+enum class JellyfinErrorCategory {
+  /**
+   * Network connectivity issues (timeout, DNS, no internet).
+   * Typically retryable.
+   */
+  Network,
+
+  /**
+   * Authentication or authorization failures (401, 403).
+   * Usually requires re-authentication, not retryable.
+   */
+  Auth,
+
+  /**
+   * Server-side errors (5xx status codes).
+   * May be retryable depending on the specific error.
+   */
+  Server,
+
+  /**
+   * Client-side errors (4xx status codes other than 401/403).
+   * Typically not retryable without modifying the request.
+   */
+  Client,
+
+  /**
+   * Errors that don't fit other categories.
+   * May or may not be retryable.
+   */
+  Unknown,
+  ;
+
+  companion object {
+    /**
+     * Determines the [JellyfinErrorCategory] for a given HTTP status code.
+     *
+     * @param statusCode The HTTP status code, or null for non-HTTP errors.
+     * @return The corresponding error category.
+     */
+    fun fromStatusCode(statusCode: Int?): JellyfinErrorCategory =
+      when {
+        statusCode == null -> Unknown
+        statusCode == 401 || statusCode == 403 -> Auth
+        statusCode in 400..499 -> Client
+        statusCode in 500..599 -> Server
+        else -> Unknown
+      }
+
+    /**
+     * Determines the [JellyfinErrorCategory] for a given [Throwable].
+     *
+     * Maps common exception types to their most likely error category.
+     */
+    fun fromThrowable(throwable: Throwable): JellyfinErrorCategory =
+      when {
+        throwable.isNetworkError() -> Network
+        else -> Unknown
+      }
+  }
+}
+
+/**
+ * Returns `true` if this error category is typically retryable.
+ */
+val JellyfinErrorCategory.isRetryable: Boolean
+  get() = when(this) {
+    JellyfinErrorCategory.Network -> true
+    JellyfinErrorCategory.Server -> true
+    JellyfinErrorCategory.Auth -> false
+    JellyfinErrorCategory.Client -> false
+    JellyfinErrorCategory.Unknown -> false
+  }
+
+/**
+ * Heuristic check for whether a [Throwable] represents a network connectivity issue.
+ *
+ * Checks the exception class name hierarchy since Ktor and platform-specific
+ * network exceptions aren't available in commonMain.
+ */
+private fun Throwable.isNetworkError(): Boolean {
+  val name = this::class.simpleName.orEmpty()
+  return name.contains("Timeout", ignoreCase = true) ||
+    name.contains("Connect", ignoreCase = true) ||
+    name.contains("Socket", ignoreCase = true) ||
+    name.contains("UnknownHost", ignoreCase = true) ||
+    name.contains("NoRouteToHost", ignoreCase = true) ||
+    name.contains("Network", ignoreCase = true) ||
+    cause?.isNetworkError() == true
+}

--- a/common/src/commonMain/kotlin/com/eygraber/jellyfin/common/JellyfinResultFlowExtensions.kt
+++ b/common/src/commonMain/kotlin/com/eygraber/jellyfin/common/JellyfinResultFlowExtensions.kt
@@ -1,0 +1,95 @@
+package com.eygraber.jellyfin.common
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Transforms each emitted [JellyfinResult.Success] value using the given [mapper].
+ *
+ * Error results pass through unchanged.
+ */
+fun <T, R> Flow<JellyfinResult<T>>.mapSuccess(
+  mapper: (T) -> R,
+): Flow<JellyfinResult<R>> = map { result ->
+  result.mapSuccessTo { mapper(this) }
+}
+
+/**
+ * Transforms each emitted [JellyfinResult.Success] value using the given [mapper]
+ * that itself returns a [JellyfinResult].
+ *
+ * Error results pass through unchanged.
+ */
+fun <T, R> Flow<JellyfinResult<T>>.flatMapSuccess(
+  mapper: (T) -> JellyfinResult<R>,
+): Flow<JellyfinResult<R>> = map { result ->
+  result.flatMapSuccessTo { mapper(this) }
+}
+
+/**
+ * Filters the flow to only emit successful result values,
+ * discarding errors.
+ */
+fun <T> Flow<JellyfinResult<T>>.filterSuccess(): Flow<T> =
+  mapNotNull { result -> result.successOrNull }
+
+/**
+ * Filters the flow to only emit error results, discarding successes.
+ */
+fun <T> Flow<JellyfinResult<T>>.filterErrors(): Flow<JellyfinResult.Error> =
+  mapNotNull { result -> result as? JellyfinResult.Error }
+
+/**
+ * Invokes [action] for each error emitted by this flow.
+ *
+ * The flow continues to emit all values unchanged.
+ */
+fun <T> Flow<JellyfinResult<T>>.onEachError(
+  action: (JellyfinResult.Error) -> Unit,
+): Flow<JellyfinResult<T>> = onEach { result ->
+  if(result is JellyfinResult.Error) {
+    action(result)
+  }
+}
+
+/**
+ * Invokes [action] for each success value emitted by this flow.
+ *
+ * The flow continues to emit all values unchanged.
+ */
+fun <T> Flow<JellyfinResult<T>>.onEachSuccess(
+  action: (T) -> Unit,
+): Flow<JellyfinResult<T>> = onEach { result ->
+  if(result is JellyfinResult.Success) {
+    action(result.value)
+  }
+}
+
+/**
+ * Catches exceptions in the upstream flow and converts them to [JellyfinResult.Error].
+ *
+ * [CancellationException] is always rethrown and never caught.
+ */
+fun <T> Flow<JellyfinResult<T>>.catchAsResult(): Flow<JellyfinResult<T>> =
+  catch { error ->
+    if(error is CancellationException) throw error
+    emit(
+      JellyfinResult.Error.Detailed(
+        details = error,
+        message = error.message,
+        isEphemeral = true,
+      ),
+    )
+  }
+
+/**
+ * Wraps each element of a plain [Flow] into a [JellyfinResult.Success],
+ * catching any exceptions and converting them to [JellyfinResult.Error].
+ */
+fun <T> Flow<T>.asResultFlow(): Flow<JellyfinResult<T>> =
+  map<T, JellyfinResult<T>> { JellyfinResult.Success(it) }
+    .catchAsResult()

--- a/common/src/commonMain/kotlin/com/eygraber/jellyfin/common/Retry.kt
+++ b/common/src/commonMain/kotlin/com/eygraber/jellyfin/common/Retry.kt
@@ -1,0 +1,83 @@
+package com.eygraber.jellyfin.common
+
+import kotlinx.coroutines.delay
+import kotlin.math.min
+import kotlin.math.pow
+
+/**
+ * Configuration for retry behavior with exponential backoff.
+ *
+ * @param maxRetries The maximum number of retry attempts (0 means no retries).
+ * @param initialDelayMs The delay before the first retry, in milliseconds.
+ * @param maxDelayMs The maximum delay between retries, in milliseconds.
+ * @param multiplier The multiplier applied to the delay after each retry.
+ * @param shouldRetry A predicate that determines whether a given error should be retried.
+ */
+data class RetryConfig(
+  val maxRetries: Int = DEFAULT_MAX_RETRIES,
+  val initialDelayMs: Long = DEFAULT_INITIAL_DELAY_MS,
+  val maxDelayMs: Long = DEFAULT_MAX_DELAY_MS,
+  val multiplier: Double = DEFAULT_MULTIPLIER,
+  val shouldRetry: (JellyfinResult.Error) -> Boolean = { true },
+) {
+  companion object {
+    const val DEFAULT_MAX_RETRIES = 3
+    const val DEFAULT_INITIAL_DELAY_MS = 1_000L
+    const val DEFAULT_MAX_DELAY_MS = 30_000L
+    const val DEFAULT_MULTIPLIER = 2.0
+  }
+}
+
+/**
+ * Executes [block] with retry logic using exponential backoff.
+ *
+ * If [block] returns a [JellyfinResult.Error] and [RetryConfig.shouldRetry] returns `true`,
+ * the operation is retried up to [RetryConfig.maxRetries] times with increasing delays.
+ *
+ * @param config The retry configuration.
+ * @param block The operation to execute and potentially retry.
+ * @return The result of the last attempt.
+ */
+@Suppress("ReturnCount")
+suspend fun <T> retryWithBackoff(
+  config: RetryConfig = RetryConfig(),
+  block: suspend () -> JellyfinResult<T>,
+): JellyfinResult<T> {
+  var lastResult: JellyfinResult<T> = block()
+
+  repeat(config.maxRetries) { attempt ->
+    val current = lastResult
+    when {
+      current.isSuccess() -> return current
+
+      current is JellyfinResult.Error && !config.shouldRetry(current) ->
+        return current
+
+      else -> {
+        val delayMs = calculateDelay(
+          attempt = attempt,
+          initialDelayMs = config.initialDelayMs,
+          maxDelayMs = config.maxDelayMs,
+          multiplier = config.multiplier,
+        )
+        delay(delayMs)
+        lastResult = block()
+      }
+    }
+  }
+
+  return lastResult
+}
+
+/**
+ * Calculates the delay for a given retry attempt using exponential backoff.
+ */
+internal fun calculateDelay(
+  attempt: Int,
+  initialDelayMs: Long,
+  maxDelayMs: Long,
+  multiplier: Double,
+): Long {
+  val exponentialDelay = initialDelayMs * multiplier.pow(attempt.toDouble())
+  return min(a = exponentialDelay.toLong(), b = maxDelayMs)
+}

--- a/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/JellyfinErrorCategoryTest.kt
+++ b/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/JellyfinErrorCategoryTest.kt
@@ -1,0 +1,107 @@
+package com.eygraber.jellyfin.common
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class JellyfinErrorCategoryTest {
+  @Test
+  fun status_401_maps_to_auth() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = 401) shouldBe JellyfinErrorCategory.Auth
+  }
+
+  @Test
+  fun status_403_maps_to_auth() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = 403) shouldBe JellyfinErrorCategory.Auth
+  }
+
+  @Test
+  fun status_400_maps_to_client() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = 400) shouldBe JellyfinErrorCategory.Client
+  }
+
+  @Test
+  fun status_404_maps_to_client() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = 404) shouldBe JellyfinErrorCategory.Client
+  }
+
+  @Test
+  fun status_500_maps_to_server() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = 500) shouldBe JellyfinErrorCategory.Server
+  }
+
+  @Test
+  fun status_503_maps_to_server() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = 503) shouldBe JellyfinErrorCategory.Server
+  }
+
+  @Test
+  fun null_status_maps_to_unknown() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = null) shouldBe JellyfinErrorCategory.Unknown
+  }
+
+  @Test
+  fun unexpected_status_maps_to_unknown() {
+    JellyfinErrorCategory.fromStatusCode(statusCode = 600) shouldBe JellyfinErrorCategory.Unknown
+  }
+
+  @Test
+  fun timeout_exception_maps_to_network() {
+    class TimeoutException : Exception("Request timed out")
+    JellyfinErrorCategory.fromThrowable(TimeoutException()) shouldBe JellyfinErrorCategory.Network
+  }
+
+  @Test
+  fun connect_exception_maps_to_network() {
+    class ConnectException : Exception("Connection refused")
+    JellyfinErrorCategory.fromThrowable(ConnectException()) shouldBe JellyfinErrorCategory.Network
+  }
+
+  @Test
+  fun socket_exception_maps_to_network() {
+    class SocketTimeoutException : Exception("Socket timeout")
+    JellyfinErrorCategory.fromThrowable(SocketTimeoutException()) shouldBe JellyfinErrorCategory.Network
+  }
+
+  @Test
+  fun unknown_host_exception_maps_to_network() {
+    class UnknownHostException : Exception("Unknown host")
+    JellyfinErrorCategory.fromThrowable(UnknownHostException()) shouldBe JellyfinErrorCategory.Network
+  }
+
+  @Test
+  fun generic_exception_maps_to_unknown() {
+    JellyfinErrorCategory.fromThrowable(RuntimeException("oops")) shouldBe JellyfinErrorCategory.Unknown
+  }
+
+  @Test
+  fun network_category_is_retryable() {
+    JellyfinErrorCategory.Network.isRetryable shouldBe true
+  }
+
+  @Test
+  fun server_category_is_retryable() {
+    JellyfinErrorCategory.Server.isRetryable shouldBe true
+  }
+
+  @Test
+  fun auth_category_is_not_retryable() {
+    JellyfinErrorCategory.Auth.isRetryable shouldBe false
+  }
+
+  @Test
+  fun client_category_is_not_retryable() {
+    JellyfinErrorCategory.Client.isRetryable shouldBe false
+  }
+
+  @Test
+  fun unknown_category_is_not_retryable() {
+    JellyfinErrorCategory.Unknown.isRetryable shouldBe false
+  }
+
+  @Test
+  fun nested_network_exception_detected_via_cause() {
+    class ConnectException : Exception("Connection refused")
+    val wrapped = RuntimeException("Wrapper", ConnectException())
+    JellyfinErrorCategory.fromThrowable(wrapped) shouldBe JellyfinErrorCategory.Network
+  }
+}

--- a/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/JellyfinResultFlowExtensionsTest.kt
+++ b/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/JellyfinResultFlowExtensionsTest.kt
@@ -1,0 +1,176 @@
+package com.eygraber.jellyfin.common
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class JellyfinResultFlowExtensionsTest {
+  @Test
+  fun mapSuccess_transforms_success_values() {
+    runTest {
+      val results = flowOf(
+        JellyfinResult.Success(1),
+        JellyfinResult.Success(2),
+        JellyfinResult.Success(3),
+      ).mapSuccess { it * 10 }.toList()
+
+      results.size shouldBe 3
+      results[0].successOrNull shouldBe 10
+      results[1].successOrNull shouldBe 20
+      results[2].successOrNull shouldBe 30
+    }
+  }
+
+  @Test
+  fun mapSuccess_passes_through_errors() {
+    runTest {
+      val error = JellyfinResult.Error.Generic(message = "fail", isEphemeral = true)
+      val results = flowOf<JellyfinResult<Int>>(
+        JellyfinResult.Success(1),
+        error,
+        JellyfinResult.Success(3),
+      ).mapSuccess { it * 10 }.toList()
+
+      results.size shouldBe 3
+      results[0].successOrNull shouldBe 10
+      results[1].isError() shouldBe true
+      results[2].successOrNull shouldBe 30
+    }
+  }
+
+  @Test
+  fun flatMapSuccess_chains_results() {
+    runTest {
+      val results = flowOf(
+        JellyfinResult.Success(42),
+      ).flatMapSuccess { value ->
+        JellyfinResult.Success("Number: $value")
+      }.toList()
+
+      results.size shouldBe 1
+      results[0].successOrNull shouldBe "Number: 42"
+    }
+  }
+
+  @Test
+  fun flatMapSuccess_can_produce_error() {
+    runTest {
+      val results = flowOf(
+        JellyfinResult.Success(42),
+      ).flatMapSuccess {
+        JellyfinResult.Error.Generic(message = "mapped to error", isEphemeral = true)
+      }.toList()
+
+      results.size shouldBe 1
+      results[0].isError() shouldBe true
+    }
+  }
+
+  @Test
+  fun filterSuccess_extracts_success_values() {
+    runTest {
+      val values = flowOf<JellyfinResult<String>>(
+        JellyfinResult.Success("a"),
+        JellyfinResult.Error.Generic(message = "fail", isEphemeral = true),
+        JellyfinResult.Success("b"),
+      ).filterSuccess().toList()
+
+      values shouldContainExactly listOf("a", "b")
+    }
+  }
+
+  @Test
+  fun filterErrors_extracts_error_values() {
+    runTest {
+      val errors = flowOf<JellyfinResult<String>>(
+        JellyfinResult.Success("a"),
+        JellyfinResult.Error.Generic(message = "fail1", isEphemeral = true),
+        JellyfinResult.Success("b"),
+        JellyfinResult.Error.Generic(message = "fail2", isEphemeral = false),
+      ).filterErrors().toList()
+
+      errors.size shouldBe 2
+      errors[0].message shouldBe "fail1"
+      errors[1].message shouldBe "fail2"
+    }
+  }
+
+  @Test
+  fun onEachSuccess_invokes_action_for_successes() {
+    runTest {
+      val captured = mutableListOf<String>()
+
+      flowOf<JellyfinResult<String>>(
+        JellyfinResult.Success("a"),
+        JellyfinResult.Error.Generic(message = "fail", isEphemeral = true),
+        JellyfinResult.Success("b"),
+      ).onEachSuccess { captured.add(it) }.toList()
+
+      captured shouldContainExactly listOf("a", "b")
+    }
+  }
+
+  @Test
+  fun onEachError_invokes_action_for_errors() {
+    runTest {
+      val captured = mutableListOf<String?>()
+
+      flowOf<JellyfinResult<String>>(
+        JellyfinResult.Success("a"),
+        JellyfinResult.Error.Generic(message = "fail1", isEphemeral = true),
+        JellyfinResult.Success("b"),
+        JellyfinResult.Error.Generic(message = "fail2", isEphemeral = false),
+      ).onEachError { captured.add(it.message) }.toList()
+
+      captured shouldContainExactly listOf("fail1", "fail2")
+    }
+  }
+
+  @Test
+  fun catchAsResult_converts_exceptions_to_errors() {
+    runTest {
+      val results = flow<JellyfinResult<String>> {
+        emit(JellyfinResult.Success("before"))
+        throw RuntimeException("flow failed")
+      }.catchAsResult().toList()
+
+      results.size shouldBe 2
+      results[0].successOrNull shouldBe "before"
+      results[1].isError() shouldBe true
+      results[1].errorMessageOrNull shouldBe "flow failed"
+    }
+  }
+
+  @Test
+  fun asResultFlow_wraps_values_in_success() {
+    runTest {
+      val results = flowOf("a", "b", "c").asResultFlow().toList()
+
+      results.size shouldBe 3
+      results.forEach {
+        it.shouldBeInstanceOf<JellyfinResult.Success<String>>()
+      }
+      results.map { it.successOrNull } shouldContainExactly listOf("a", "b", "c")
+    }
+  }
+
+  @Test
+  fun asResultFlow_catches_upstream_exceptions() {
+    runTest {
+      val results = flow {
+        emit("ok")
+        throw RuntimeException("oops")
+      }.asResultFlow().toList()
+
+      results.size shouldBe 2
+      results[0].successOrNull shouldBe "ok"
+      results[1].isError() shouldBe true
+      results[1].errorMessageOrNull shouldBe "oops"
+    }
+  }
+}

--- a/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/JellyfinResultTest.kt
+++ b/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/JellyfinResultTest.kt
@@ -1,0 +1,287 @@
+package com.eygraber.jellyfin.common
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+class JellyfinResultTest {
+  @Test
+  fun success_isSuccess_returns_true() {
+    val result: JellyfinResult<String> = JellyfinResult.Success("hello")
+    result.isSuccess() shouldBe true
+  }
+
+  @Test
+  fun success_isError_returns_false() {
+    val result: JellyfinResult<String> = JellyfinResult.Success("hello")
+    result.isError() shouldBe false
+  }
+
+  @Test
+  fun error_isError_returns_true() {
+    val result: JellyfinResult<String> = JellyfinResult.Error.Generic(
+      message = "failure",
+      isEphemeral = false,
+    )
+    result.isError() shouldBe true
+  }
+
+  @Test
+  fun error_isSuccess_returns_false() {
+    val result: JellyfinResult<String> = JellyfinResult.Error.Generic(
+      message = "failure",
+      isEphemeral = false,
+    )
+    result.isSuccess() shouldBe false
+  }
+
+  @Test
+  fun successOrNull_returns_value_for_success() {
+    val result: JellyfinResult<String> = JellyfinResult.Success("hello")
+    result.successOrNull shouldBe "hello"
+  }
+
+  @Test
+  fun successOrNull_returns_null_for_error() {
+    val result: JellyfinResult<String> = JellyfinResult.Error()
+    result.successOrNull.shouldBeNull()
+  }
+
+  @Test
+  fun throwableOrNull_returns_throwable_for_detailed_error() {
+    val exception = RuntimeException("oops")
+    val result: JellyfinResult<String> = JellyfinResult.Error.Detailed(
+      details = exception,
+      message = "oops",
+      isEphemeral = true,
+    )
+    result.throwableOrNull shouldBe exception
+  }
+
+  @Test
+  fun throwableOrNull_returns_null_for_generic_error() {
+    val result: JellyfinResult<String> = JellyfinResult.Error.Generic(
+      message = "oops",
+      isEphemeral = true,
+    )
+    result.throwableOrNull.shouldBeNull()
+  }
+
+  @Test
+  fun throwableOrNull_returns_null_for_success() {
+    val result: JellyfinResult<String> = JellyfinResult.Success("hello")
+    result.throwableOrNull.shouldBeNull()
+  }
+
+  @Test
+  fun errorMessageOrNull_returns_message_for_error() {
+    val result: JellyfinResult<String> = JellyfinResult.Error.Generic(
+      message = "something went wrong",
+      isEphemeral = false,
+    )
+    result.errorMessageOrNull shouldBe "something went wrong"
+  }
+
+  @Test
+  fun errorMessageOrNull_returns_null_for_success() {
+    val result: JellyfinResult<String> = JellyfinResult.Success("hello")
+    result.errorMessageOrNull.shouldBeNull()
+  }
+
+  @Test
+  fun errorDetailOrNull_returns_details_for_detailed_error() {
+    val result: JellyfinResult<String> = JellyfinResult.Error.Detailed(
+      details = "some details",
+      message = "oops",
+      isEphemeral = true,
+    )
+    result.errorDetailOrNull shouldBe "some details"
+  }
+
+  @Test
+  fun errorDetailOrNull_returns_null_for_generic_error() {
+    val result: JellyfinResult<String> = JellyfinResult.Error.Generic(
+      message = "oops",
+      isEphemeral = true,
+    )
+    result.errorDetailOrNull.shouldBeNull()
+  }
+
+  @Test
+  fun mapToUnit_converts_success_to_unit_success() {
+    val result = JellyfinResult.Success("hello").mapToUnit()
+    result.shouldBeInstanceOf<JellyfinResult.Success<Unit>>()
+    result.value shouldBe Unit
+  }
+
+  @Test
+  fun mapToUnit_passes_through_error() {
+    val error = JellyfinResult.Error.Generic(message = "fail", isEphemeral = false)
+    val result = error.mapToUnit()
+    result shouldBe error
+  }
+
+  @Test
+  fun mapSuccessTo_transforms_success_value() {
+    val result = JellyfinResult.Success(42).mapSuccessTo { toString() }
+    result.shouldBeInstanceOf<JellyfinResult.Success<String>>()
+    result.value shouldBe "42"
+  }
+
+  @Test
+  fun mapSuccessTo_passes_through_error() {
+    val error: JellyfinResult<Int> = JellyfinResult.Error.Generic(
+      message = "fail",
+      isEphemeral = false,
+    )
+    val result = error.mapSuccessTo { toString() }
+    result.isError() shouldBe true
+  }
+
+  @Test
+  fun flatMapSuccessTo_chains_success() {
+    val result = JellyfinResult.Success(42).flatMapSuccessTo {
+      JellyfinResult.Success(this * 2)
+    }
+    result.shouldBeInstanceOf<JellyfinResult.Success<Int>>()
+    result.value shouldBe 84
+  }
+
+  @Test
+  fun flatMapSuccessTo_chains_to_error() {
+    val result = JellyfinResult.Success(42).flatMapSuccessTo {
+      JellyfinResult.Error.Generic(message = "failed", isEphemeral = true)
+    }
+    result.isError() shouldBe true
+  }
+
+  @Test
+  fun flatMapSuccessTo_passes_through_error() {
+    val error: JellyfinResult<Int> = JellyfinResult.Error.Generic(
+      message = "fail",
+      isEphemeral = false,
+    )
+    val result = error.flatMapSuccessTo { JellyfinResult.Success(99) }
+    result.isError() shouldBe true
+    result.errorMessageOrNull shouldBe "fail"
+  }
+
+  @Test
+  fun andThen_executes_block_on_success() {
+    var wasExecuted = false
+    val result = JellyfinResult.Success("hello").andThen { wasExecuted = true }
+    wasExecuted shouldBe true
+    result.isSuccess() shouldBe true
+  }
+
+  @Test
+  fun andThen_does_not_execute_block_on_error() {
+    var wasExecuted = false
+    val error: JellyfinResult<String> = JellyfinResult.Error.Generic(
+      message = "fail",
+      isEphemeral = false,
+    )
+    error.andThen { wasExecuted = true }
+    wasExecuted shouldBe false
+  }
+
+  @Test
+  fun andThen_catches_block_exceptions() {
+    val result = JellyfinResult.Success("hello").andThen {
+      error("intentional failure")
+    }
+    result.isError() shouldBe true
+  }
+
+  @Test
+  fun doOnSuccess_executes_block_on_success() {
+    var captured: String? = null
+    JellyfinResult.Success("hello").doOnSuccess { captured = it }
+    captured shouldBe "hello"
+  }
+
+  @Test
+  fun doOnSuccess_does_not_execute_block_on_error() {
+    var captured: String? = null
+    val error: JellyfinResult<String> = JellyfinResult.Error()
+    error.doOnSuccess { captured = it }
+    captured.shouldBeNull()
+  }
+
+  @Test
+  fun doOnError_executes_block_on_error() {
+    var captured: JellyfinResult.Error? = null
+    val error: JellyfinResult<String> = JellyfinResult.Error.Generic(
+      message = "fail",
+      isEphemeral = false,
+    )
+    error.doOnError { captured = it }
+    captured.shouldNotBeNull()
+    captured.message shouldBe "fail"
+  }
+
+  @Test
+  fun doOnError_does_not_execute_block_on_success() {
+    var captured: JellyfinResult.Error? = null
+    JellyfinResult.Success("hello").doOnError { captured = it }
+    captured.shouldBeNull()
+  }
+
+  @Test
+  fun runResult_wraps_success() {
+    val result = runResult { "hello" }
+    result.shouldBeInstanceOf<JellyfinResult.Success<String>>()
+    result.value shouldBe "hello"
+  }
+
+  @Test
+  fun runResult_wraps_exception_as_error() {
+    val result = runResult { error("oops") }
+    result.isError() shouldBe true
+    result.errorMessageOrNull shouldBe "oops"
+    result.throwableOrNull.shouldNotBeNull()
+  }
+
+  @Test
+  fun unwrap_flattens_nested_success() {
+    val nested: JellyfinResult<JellyfinResult<String>> =
+      JellyfinResult.Success(JellyfinResult.Success("hello"))
+    val result = nested.unwrap()
+    result.shouldBeInstanceOf<JellyfinResult.Success<String>>()
+    result.value shouldBe "hello"
+  }
+
+  @Test
+  fun unwrap_flattens_nested_error() {
+    val nested: JellyfinResult<JellyfinResult<String>> =
+      JellyfinResult.Success(JellyfinResult.Error.Generic(message = "inner fail", isEphemeral = true))
+    val result = nested.unwrap()
+    result.isError() shouldBe true
+    result.errorMessageOrNull shouldBe "inner fail"
+  }
+
+  @Test
+  fun unwrap_passes_through_outer_error() {
+    val nested: JellyfinResult<JellyfinResult<String>> =
+      JellyfinResult.Error.Generic(message = "outer fail", isEphemeral = false)
+    val result = nested.unwrap()
+    result.isError() shouldBe true
+    result.errorMessageOrNull shouldBe "outer fail"
+  }
+
+  @Test
+  fun success_empty_returns_unit() {
+    val result = JellyfinResult.Success()
+    result.shouldBeInstanceOf<JellyfinResult.Success<Unit>>()
+    result.value shouldBe Unit
+  }
+
+  @Test
+  fun error_empty_has_null_message() {
+    val result: JellyfinResult<String> = JellyfinResult.Error()
+    result.isError() shouldBe true
+    result.errorMessageOrNull.shouldBeNull()
+  }
+}

--- a/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/RetryTest.kt
+++ b/common/src/commonTest/kotlin/com/eygraber/jellyfin/common/RetryTest.kt
@@ -1,0 +1,142 @@
+package com.eygraber.jellyfin.common
+
+import io.kotest.matchers.longs.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class RetryTest {
+  @Test
+  fun returns_success_without_retrying() {
+    runTest {
+      var callCount = 0
+      val result = retryWithBackoff(
+        config = RetryConfig(initialDelayMs = 1),
+      ) {
+        callCount++
+        JellyfinResult.Success("hello")
+      }
+
+      result.shouldBeInstanceOf<JellyfinResult.Success<String>>()
+      result.value shouldBe "hello"
+      callCount shouldBe 1
+    }
+  }
+
+  @Test
+  fun retries_on_error_up_to_max() {
+    runTest {
+      var callCount = 0
+      val result = retryWithBackoff(
+        config = RetryConfig(maxRetries = 3, initialDelayMs = 1),
+      ) {
+        callCount++
+        JellyfinResult.Error.Generic(message = "fail", isEphemeral = true)
+      }
+
+      result.isError() shouldBe true
+      callCount shouldBe 4 // 1 initial + 3 retries
+    }
+  }
+
+  @Test
+  fun succeeds_on_second_attempt() {
+    runTest {
+      var callCount = 0
+      val result = retryWithBackoff(
+        config = RetryConfig(maxRetries = 3, initialDelayMs = 1),
+      ) {
+        callCount++
+        if(callCount < 2) {
+          JellyfinResult.Error.Generic(message = "fail", isEphemeral = true)
+        }
+        else {
+          JellyfinResult.Success("recovered")
+        }
+      }
+
+      result.shouldBeInstanceOf<JellyfinResult.Success<String>>()
+      result.value shouldBe "recovered"
+      callCount shouldBe 2
+    }
+  }
+
+  @Test
+  fun stops_retrying_when_shouldRetry_returns_false() {
+    runTest {
+      var callCount = 0
+      val result = retryWithBackoff(
+        config = RetryConfig(
+          maxRetries = 5,
+          initialDelayMs = 1,
+          shouldRetry = { false },
+        ),
+      ) {
+        callCount++
+        JellyfinResult.Error.Generic(message = "non-retryable", isEphemeral = false)
+      }
+
+      result.isError() shouldBe true
+      callCount shouldBe 1
+    }
+  }
+
+  @Test
+  fun zero_retries_executes_once() {
+    runTest {
+      var callCount = 0
+      val result = retryWithBackoff(
+        config = RetryConfig(maxRetries = 0),
+      ) {
+        callCount++
+        JellyfinResult.Error.Generic(message = "fail", isEphemeral = true)
+      }
+
+      result.isError() shouldBe true
+      callCount shouldBe 1
+    }
+  }
+
+  @Test
+  fun calculateDelay_returns_correct_exponential_values() {
+    calculateDelay(
+      attempt = 0,
+      initialDelayMs = 1_000,
+      maxDelayMs = 30_000,
+      multiplier = 2.0,
+    ) shouldBe 1_000
+
+    calculateDelay(
+      attempt = 1,
+      initialDelayMs = 1_000,
+      maxDelayMs = 30_000,
+      multiplier = 2.0,
+    ) shouldBe 2_000
+
+    calculateDelay(
+      attempt = 2,
+      initialDelayMs = 1_000,
+      maxDelayMs = 30_000,
+      multiplier = 2.0,
+    ) shouldBe 4_000
+
+    calculateDelay(
+      attempt = 3,
+      initialDelayMs = 1_000,
+      maxDelayMs = 30_000,
+      multiplier = 2.0,
+    ) shouldBe 8_000
+  }
+
+  @Test
+  fun calculateDelay_respects_max_delay() {
+    val delay = calculateDelay(
+      attempt = 10,
+      initialDelayMs = 1_000,
+      maxDelayMs = 30_000,
+      multiplier = 2.0,
+    )
+    delay shouldBeLessThanOrEqual 30_000
+  }
+}


### PR DESCRIPTION
## Summary
- Added `JellyfinErrorCategory` enum classifying errors as Network, Auth, Server, Client, or Unknown with status code and throwable mapping
- Added `RetryConfig` and `retryWithBackoff()` for exponential backoff retry logic integrated with `JellyfinResult`
- Added Flow extensions: `mapSuccess`, `flatMapSuccess`, `filterSuccess`, `filterErrors`, `onEachSuccess`, `onEachError`, `catchAsResult`, `asResultFlow`
- Added comprehensive unit tests for all existing `JellyfinResult` operations (40+ tests across 4 test files)
- Added test dependencies (kotest, coroutines-test) to common module

## Technical Notes
- Error categorization uses class name heuristics for network errors (checking for "Timeout", "Connect", "Socket", etc.) since Ktor exceptions aren't available in commonMain
- Retry logic properly handles `shouldRetry` predicate for selective retrying
- Flow extensions re-throw `CancellationException` per coroutine conventions

## Test plan
- [x] `JellyfinResultTest` - 30 tests covering all existing result operations
- [x] `JellyfinErrorCategoryTest` - 13 tests for status code mapping, throwable detection, and retryability
- [x] `RetryTest` - 7 tests for retry behavior and delay calculation
- [x] `JellyfinResultFlowExtensionsTest` - 11 tests for all Flow operators
- [x] `./check` passes (lint, detekt, tests, konsist)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)