### PR TITLE
#33 Add server discovery with URL validation and version checks

### DIFF
--- a/domain/validators/src/commonMain/kotlin/com/eygraber/jellyfin/domain/validators/ServerUrlValidator.kt
+++ b/domain/validators/src/commonMain/kotlin/com/eygraber/jellyfin/domain/validators/ServerUrlValidator.kt
@@ -1,0 +1,77 @@
+package com.eygraber.jellyfin.domain.validators
+
+import androidx.compose.runtime.Immutable
+import dev.zacsweers.metro.Inject
+
+/**
+ * Validates Jellyfin server URLs.
+ *
+ * Ensures the URL is well-formed and uses an appropriate protocol.
+ * Automatically prepends "https://" if no scheme is provided.
+ */
+@Inject
+class ServerUrlValidator {
+  @Immutable
+  enum class Result {
+    Valid,
+    Empty,
+    InvalidFormat,
+    InsecureProtocol,
+  }
+
+  /**
+   * Validates the given server URL.
+   *
+   * @param url The server URL to validate.
+   * @return The validation [Result].
+   */
+  fun validate(url: CharSequence): Result =
+    when {
+      url.isBlank() -> Result.Empty
+      else -> validateFormat(url.toString().trim())
+    }
+
+  /**
+   * Normalizes a server URL by ensuring it has a scheme and trimming trailing slashes.
+   *
+   * @param url The URL to normalize.
+   * @return The normalized URL, or null if the URL is invalid.
+   */
+  fun normalize(url: String): String? {
+    val trimmed = url.trim()
+    if(trimmed.isBlank()) return null
+
+    val withScheme = when {
+      trimmed.startsWith("http://") || trimmed.startsWith("https://") -> trimmed
+      else -> "https://$trimmed"
+    }
+
+    return if(validateFormat(withScheme) != Result.InvalidFormat) {
+      withScheme.trimEnd('/')
+    }
+    else {
+      null
+    }
+  }
+
+  private fun validateFormat(url: String): Result {
+    val withScheme = when {
+      url.startsWith("http://") -> return Result.InsecureProtocol
+      url.startsWith("https://") -> url
+      else -> "https://$url"
+    }
+
+    return if(UrlPattern.matches(withScheme)) {
+      Result.Valid
+    }
+    else {
+      Result.InvalidFormat
+    }
+  }
+
+  companion object {
+    private val UrlPattern = Regex(
+      """https?://[a-zA-Z0-9\-.]+(:\d{1,5})?(/\S*)?""",
+    )
+  }
+}

--- a/domain/validators/src/commonMain/kotlin/com/eygraber/jellyfin/domain/validators/ServerVersionValidator.kt
+++ b/domain/validators/src/commonMain/kotlin/com/eygraber/jellyfin/domain/validators/ServerVersionValidator.kt
@@ -1,0 +1,53 @@
+package com.eygraber.jellyfin.domain.validators
+
+import androidx.compose.runtime.Immutable
+import dev.zacsweers.metro.Inject
+
+/**
+ * Validates Jellyfin server version compatibility.
+ *
+ * Ensures the server meets the minimum version requirements
+ * for this client to function properly.
+ */
+@Inject
+class ServerVersionValidator {
+  @Immutable
+  sealed interface Result {
+    data object Compatible : Result
+    data object Incompatible : Result
+    data object Unknown : Result
+  }
+
+  /**
+   * Checks if the given server version is compatible with this client.
+   *
+   * @param version The server version string (e.g., "10.9.0").
+   * @return The compatibility [Result].
+   */
+  fun validate(version: String?): Result {
+    if(version == null) return Result.Unknown
+
+    val parts = version.split('.').mapNotNull { it.toIntOrNull() }
+    if(parts.size < REQUIRED_VERSION_PARTS) return Result.Unknown
+
+    val major = parts[0]
+    val minor = parts[1]
+
+    return when {
+      major > MIN_MAJOR_VERSION -> Result.Compatible
+      major == MIN_MAJOR_VERSION && minor >= MIN_MINOR_VERSION -> Result.Compatible
+      else -> Result.Incompatible
+    }
+  }
+
+  companion object {
+    /**
+     * Minimum supported Jellyfin server version.
+     * Jellyfin 10.8.0 introduced several API changes this client depends on.
+     */
+    const val MIN_MAJOR_VERSION = 10
+    const val MIN_MINOR_VERSION = 8
+
+    private const val REQUIRED_VERSION_PARTS = 2
+  }
+}

--- a/domain/validators/src/commonTest/kotlin/com/eygraber/jellyfin/domain/validators/ServerUrlValidatorTest.kt
+++ b/domain/validators/src/commonTest/kotlin/com/eygraber/jellyfin/domain/validators/ServerUrlValidatorTest.kt
@@ -1,0 +1,99 @@
+package com.eygraber.jellyfin.domain.validators
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class ServerUrlValidatorTest {
+  private val validator = ServerUrlValidator()
+
+  @Test
+  fun empty_url_returns_empty() {
+    validator.validate("") shouldBe ServerUrlValidator.Result.Empty
+  }
+
+  @Test
+  fun blank_url_returns_empty() {
+    validator.validate("   ") shouldBe ServerUrlValidator.Result.Empty
+  }
+
+  @Test
+  fun valid_https_url_returns_valid() {
+    validator.validate("https://jellyfin.example.com") shouldBe ServerUrlValidator.Result.Valid
+  }
+
+  @Test
+  fun valid_url_with_port_returns_valid() {
+    validator.validate("https://jellyfin.example.com:8096") shouldBe ServerUrlValidator.Result.Valid
+  }
+
+  @Test
+  fun valid_url_with_path_returns_valid() {
+    validator.validate("https://jellyfin.example.com/jellyfin") shouldBe ServerUrlValidator.Result.Valid
+  }
+
+  @Test
+  fun url_without_scheme_returns_valid() {
+    validator.validate("jellyfin.example.com") shouldBe ServerUrlValidator.Result.Valid
+  }
+
+  @Test
+  fun http_url_returns_insecure() {
+    validator.validate("http://jellyfin.example.com") shouldBe ServerUrlValidator.Result.InsecureProtocol
+  }
+
+  @Test
+  fun invalid_url_returns_invalid_format() {
+    validator.validate("not a url at all!") shouldBe ServerUrlValidator.Result.InvalidFormat
+  }
+
+  @Test
+  fun normalize_adds_https_scheme() {
+    val result = validator.normalize("jellyfin.example.com")
+    result.shouldNotBeNull()
+    result shouldBe "https://jellyfin.example.com"
+  }
+
+  @Test
+  fun normalize_preserves_https_scheme() {
+    val result = validator.normalize("https://jellyfin.example.com")
+    result.shouldNotBeNull()
+    result shouldBe "https://jellyfin.example.com"
+  }
+
+  @Test
+  fun normalize_trims_trailing_slash() {
+    val result = validator.normalize("https://jellyfin.example.com/")
+    result.shouldNotBeNull()
+    result shouldBe "https://jellyfin.example.com"
+  }
+
+  @Test
+  fun normalize_preserves_port() {
+    val result = validator.normalize("jellyfin.example.com:8096")
+    result.shouldNotBeNull()
+    result shouldBe "https://jellyfin.example.com:8096"
+  }
+
+  @Test
+  fun normalize_returns_null_for_blank() {
+    validator.normalize("").shouldBeNull()
+    validator.normalize("  ").shouldBeNull()
+  }
+
+  @Test
+  fun normalize_returns_null_for_invalid() {
+    validator.normalize("not a url at all!").shouldBeNull()
+  }
+
+  @Test
+  fun url_with_ip_address_returns_valid() {
+    validator.validate("https://192.168.1.100:8096") shouldBe ServerUrlValidator.Result.Valid
+  }
+
+  @Test
+  fun localhost_url_returns_valid() {
+    validator.validate("https://localhost:8096") shouldBe ServerUrlValidator.Result.Valid
+  }
+}

--- a/domain/validators/src/commonTest/kotlin/com/eygraber/jellyfin/domain/validators/ServerVersionValidatorTest.kt
+++ b/domain/validators/src/commonTest/kotlin/com/eygraber/jellyfin/domain/validators/ServerVersionValidatorTest.kt
@@ -1,0 +1,69 @@
+package com.eygraber.jellyfin.domain.validators
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+class ServerVersionValidatorTest {
+  private val validator = ServerVersionValidator()
+
+  @Test
+  fun null_version_returns_unknown() {
+    validator.validate(null) shouldBe ServerVersionValidator.Result.Unknown
+  }
+
+  @Test
+  fun empty_version_returns_unknown() {
+    validator.validate("") shouldBe ServerVersionValidator.Result.Unknown
+  }
+
+  @Test
+  fun invalid_version_format_returns_unknown() {
+    validator.validate("not-a-version") shouldBe ServerVersionValidator.Result.Unknown
+  }
+
+  @Test
+  fun version_with_only_major_returns_unknown() {
+    validator.validate("10") shouldBe ServerVersionValidator.Result.Unknown
+  }
+
+  @Test
+  fun version_10_8_0_is_compatible() {
+    validator.validate("10.8.0").shouldBeInstanceOf<ServerVersionValidator.Result.Compatible>()
+  }
+
+  @Test
+  fun version_10_9_0_is_compatible() {
+    validator.validate("10.9.0").shouldBeInstanceOf<ServerVersionValidator.Result.Compatible>()
+  }
+
+  @Test
+  fun version_10_10_0_is_compatible() {
+    validator.validate("10.10.0").shouldBeInstanceOf<ServerVersionValidator.Result.Compatible>()
+  }
+
+  @Test
+  fun version_11_0_0_is_compatible() {
+    validator.validate("11.0.0").shouldBeInstanceOf<ServerVersionValidator.Result.Compatible>()
+  }
+
+  @Test
+  fun version_10_7_9_is_incompatible() {
+    validator.validate("10.7.9").shouldBeInstanceOf<ServerVersionValidator.Result.Incompatible>()
+  }
+
+  @Test
+  fun version_10_0_0_is_incompatible() {
+    validator.validate("10.0.0").shouldBeInstanceOf<ServerVersionValidator.Result.Incompatible>()
+  }
+
+  @Test
+  fun version_9_99_99_is_incompatible() {
+    validator.validate("9.99.99").shouldBeInstanceOf<ServerVersionValidator.Result.Incompatible>()
+  }
+
+  @Test
+  fun version_with_extra_parts_is_compatible() {
+    validator.validate("10.9.0.1234").shouldBeInstanceOf<ServerVersionValidator.Result.Compatible>()
+  }
+}

--- a/services/sdk/impl/build.gradle.kts
+++ b/services/sdk/impl/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
       api(projects.services.sdk.public)
 
       implementation(projects.di)
+      implementation(projects.domain.validators)
       implementation(projects.services.logging.public)
 
       implementation(libs.kotlinx.coroutines.core)

--- a/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinServerDiscoveryService.kt
+++ b/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinServerDiscoveryService.kt
@@ -1,0 +1,108 @@
+package com.eygraber.jellyfin.services.sdk.impl
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.common.isSuccess
+import com.eygraber.jellyfin.common.mapSuccessTo
+import com.eygraber.jellyfin.domain.validators.ServerUrlValidator
+import com.eygraber.jellyfin.domain.validators.ServerVersionValidator
+import com.eygraber.jellyfin.sdk.core.model.ServerDiscoveryInfo
+import com.eygraber.jellyfin.services.logging.JellyfinLogger
+import com.eygraber.jellyfin.services.sdk.JellyfinServerDiscoveryService
+import com.eygraber.jellyfin.services.sdk.JellyfinServerService
+import com.eygraber.jellyfin.services.sdk.ServerConnectionInfo
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Default implementation of [JellyfinServerDiscoveryService].
+ *
+ * Orchestrates server discovery, URL validation, connection,
+ * and version compatibility checking.
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultJellyfinServerDiscoveryService(
+  private val serverService: JellyfinServerService,
+  private val urlValidator: ServerUrlValidator,
+  private val versionValidator: ServerVersionValidator,
+  private val logger: JellyfinLogger,
+) : JellyfinServerDiscoveryService {
+  override fun discoverServers(timeoutMs: Long): Flow<ServerDiscoveryInfo> {
+    logger.info(tag = TAG, message = "Starting server discovery (timeout: ${timeoutMs}ms)")
+    return serverService.discoverServers(timeoutMs = timeoutMs)
+  }
+
+  @Suppress("ReturnCount")
+  override suspend fun connectToServer(
+    serverUrl: String,
+  ): JellyfinResult<ServerConnectionInfo> {
+    // Step 1: Validate and normalize the URL
+    val validationResult = urlValidator.validate(serverUrl)
+    if(validationResult != ServerUrlValidator.Result.Valid) {
+      val errorMessage = when(validationResult) {
+        ServerUrlValidator.Result.Empty -> "Server URL is required"
+        ServerUrlValidator.Result.InvalidFormat -> "Invalid server URL format"
+        ServerUrlValidator.Result.InsecureProtocol -> "HTTP connections are not supported, use HTTPS"
+        ServerUrlValidator.Result.Valid -> error("Unexpected valid result")
+      }
+      logger.warn(tag = TAG, message = "URL validation failed: $errorMessage")
+      return JellyfinResult.Error(message = errorMessage, isEphemeral = false)
+    }
+
+    val normalizedUrl = urlValidator.normalize(serverUrl)
+      ?: return JellyfinResult.Error(
+        message = "Failed to normalize server URL",
+        isEphemeral = false,
+      )
+
+    logger.info(tag = TAG, message = "Connecting to server: $normalizedUrl")
+
+    // Step 2: Connect to the server
+    val connectionResult = serverService.connectToServer(normalizedUrl)
+    if(!connectionResult.isSuccess()) return connectionResult.mapSuccessTo { error("unreachable") }
+
+    val systemInfo = connectionResult.value
+
+    // Step 3: Check version compatibility
+    val versionResult = versionValidator.validate(systemInfo.version)
+    val isCompatible = versionResult is ServerVersionValidator.Result.Compatible
+
+    if(!isCompatible && versionResult is ServerVersionValidator.Result.Incompatible) {
+      logger.warn(
+        tag = TAG,
+        message = "Server version ${systemInfo.version.orEmpty()} is below minimum " +
+          "${ServerVersionValidator.MIN_MAJOR_VERSION}.${ServerVersionValidator.MIN_MINOR_VERSION}.0",
+      )
+    }
+
+    logger.info(
+      tag = TAG,
+      message = "Server connection established: ${systemInfo.serverName.orEmpty()} " +
+        "(${systemInfo.version.orEmpty()}, compatible=$isCompatible)",
+    )
+
+    return JellyfinResult.Success(
+      ServerConnectionInfo(
+        serverUrl = normalizedUrl,
+        systemInfo = systemInfo,
+        isVersionCompatible = isCompatible,
+      ),
+    )
+  }
+
+  override suspend fun connectToDiscoveredServer(
+    discoveryInfo: ServerDiscoveryInfo,
+  ): JellyfinResult<ServerConnectionInfo> {
+    logger.info(
+      tag = TAG,
+      message = "Connecting to discovered server: ${discoveryInfo.name.orEmpty()} at ${discoveryInfo.address}",
+    )
+    return connectToServer(discoveryInfo.address)
+  }
+
+  companion object {
+    private const val TAG = "ServerDiscovery"
+  }
+}

--- a/services/sdk/impl/src/commonTest/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinServerDiscoveryServiceTest.kt
+++ b/services/sdk/impl/src/commonTest/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinServerDiscoveryServiceTest.kt
@@ -1,0 +1,198 @@
+package com.eygraber.jellyfin.services.sdk.impl
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.common.isError
+import com.eygraber.jellyfin.common.isSuccess
+import com.eygraber.jellyfin.sdk.core.model.PublicSystemInfo
+import com.eygraber.jellyfin.sdk.core.model.ServerDiscoveryInfo
+import com.eygraber.jellyfin.sdk.core.model.SystemInfo
+import com.eygraber.jellyfin.services.logging.JellyfinLogger
+import com.eygraber.jellyfin.services.sdk.JellyfinServerService
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class DefaultJellyfinServerDiscoveryServiceTest {
+  private val noopLogger = object : JellyfinLogger {
+    override fun verbose(tag: String, message: String) {}
+    override fun debug(tag: String, message: String) {}
+    override fun info(tag: String, message: String) {}
+    override fun warn(tag: String, message: String, throwable: Throwable?) {}
+    override fun error(tag: String, message: String, throwable: Throwable?) {}
+  }
+
+  private fun createFakeServerService(
+    connectResult: JellyfinResult<PublicSystemInfo> = JellyfinResult.Success(
+      PublicSystemInfo(
+        serverName = "Test Server",
+        version = "10.9.0",
+        id = "server-id-123",
+      ),
+    ),
+  ): JellyfinServerService = object : JellyfinServerService {
+    override fun discoverServers(timeoutMs: Long): Flow<ServerDiscoveryInfo> = emptyFlow()
+
+    override suspend fun connectToServer(serverUrl: String): JellyfinResult<PublicSystemInfo> =
+      connectResult
+
+    override suspend fun getSystemInfo(): JellyfinResult<SystemInfo> =
+      JellyfinResult.Error(message = "Not implemented", isEphemeral = false)
+
+    override suspend fun ping(): JellyfinResult<String> =
+      JellyfinResult.Error(message = "Not implemented", isEphemeral = false)
+  }
+
+  private fun createService(
+    serverService: JellyfinServerService = createFakeServerService(),
+  ): DefaultJellyfinServerDiscoveryService {
+    val urlValidator = com.eygraber.jellyfin.domain.validators.ServerUrlValidator()
+    val versionValidator = com.eygraber.jellyfin.domain.validators.ServerVersionValidator()
+    return DefaultJellyfinServerDiscoveryService(
+      serverService = serverService,
+      urlValidator = urlValidator,
+      versionValidator = versionValidator,
+      logger = noopLogger,
+    )
+  }
+
+  @Test
+  fun connect_with_valid_url_returns_connection_info() {
+    runTest {
+      val service = createService()
+      val result = service.connectToServer("https://jellyfin.example.com")
+
+      result.isSuccess() shouldBe true
+      val info = (result as JellyfinResult.Success).value
+      info.serverUrl shouldBe "https://jellyfin.example.com"
+      info.systemInfo.serverName shouldBe "Test Server"
+      info.isVersionCompatible shouldBe true
+    }
+  }
+
+  @Test
+  fun connect_with_url_without_scheme_normalizes() {
+    runTest {
+      val service = createService()
+      val result = service.connectToServer("jellyfin.example.com")
+
+      result.isSuccess() shouldBe true
+      val info = (result as JellyfinResult.Success).value
+      info.serverUrl shouldBe "https://jellyfin.example.com"
+    }
+  }
+
+  @Test
+  fun connect_with_empty_url_returns_error() {
+    runTest {
+      val service = createService()
+      val result = service.connectToServer("")
+
+      result.isError() shouldBe true
+      val error = result.shouldBeInstanceOf<JellyfinResult.Error.Generic>()
+      error.message shouldBe "Server URL is required"
+    }
+  }
+
+  @Test
+  fun connect_with_http_url_returns_error() {
+    runTest {
+      val service = createService()
+      val result = service.connectToServer("http://jellyfin.example.com")
+
+      result.isError() shouldBe true
+      val error = result.shouldBeInstanceOf<JellyfinResult.Error.Generic>()
+      error.message shouldBe "HTTP connections are not supported, use HTTPS"
+    }
+  }
+
+  @Test
+  fun connect_with_incompatible_version_marks_incompatible() {
+    runTest {
+      val serverService = createFakeServerService(
+        connectResult = JellyfinResult.Success(
+          PublicSystemInfo(
+            serverName = "Old Server",
+            version = "10.7.0",
+            id = "old-server",
+          ),
+        ),
+      )
+      val service = createService(serverService = serverService)
+      val result = service.connectToServer("https://old.example.com")
+
+      result.isSuccess() shouldBe true
+      val info = (result as JellyfinResult.Success).value
+      info.isVersionCompatible shouldBe false
+    }
+  }
+
+  @Test
+  fun connect_with_server_error_propagates_error() {
+    runTest {
+      val serverService = createFakeServerService(
+        connectResult = JellyfinResult.Error(
+          message = "Connection refused",
+          isEphemeral = true,
+        ),
+      )
+      val service = createService(serverService = serverService)
+      val result = service.connectToServer("https://unreachable.example.com")
+
+      result.isError() shouldBe true
+    }
+  }
+
+  @Test
+  fun connect_to_discovered_server_delegates_to_connect() {
+    runTest {
+      val service = createService()
+      val discoveryInfo = ServerDiscoveryInfo(
+        address = "https://discovered.example.com",
+        id = "disc-server",
+        name = "Discovered Server",
+      )
+      val result = service.connectToDiscoveredServer(discoveryInfo)
+
+      result.isSuccess() shouldBe true
+      val info = (result as JellyfinResult.Success).value
+      info.serverUrl shouldBe "https://discovered.example.com"
+    }
+  }
+
+  @Test
+  fun connect_with_trailing_slash_normalizes() {
+    runTest {
+      val service = createService()
+      val result = service.connectToServer("https://jellyfin.example.com/")
+
+      result.isSuccess() shouldBe true
+      val info = (result as JellyfinResult.Success).value
+      info.serverUrl shouldBe "https://jellyfin.example.com"
+    }
+  }
+
+  @Test
+  fun connect_with_unknown_version_marks_compatible() {
+    runTest {
+      val serverService = createFakeServerService(
+        connectResult = JellyfinResult.Success(
+          PublicSystemInfo(
+            serverName = "Mystery Server",
+            version = null,
+            id = "mystery",
+          ),
+        ),
+      )
+      val service = createService(serverService = serverService)
+      val result = service.connectToServer("https://mystery.example.com")
+
+      result.isSuccess() shouldBe true
+      // Unknown version should NOT be marked as compatible
+      val info = (result as JellyfinResult.Success).value
+      info.isVersionCompatible shouldBe false
+    }
+  }
+}

--- a/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinServerDiscoveryService.kt
+++ b/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinServerDiscoveryService.kt
@@ -1,0 +1,51 @@
+package com.eygraber.jellyfin.services.sdk
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.sdk.core.model.ServerDiscoveryInfo
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * High-level service for discovering and connecting to Jellyfin servers.
+ *
+ * Orchestrates server discovery, URL validation, server connection,
+ * and version compatibility checking into a unified flow.
+ */
+interface JellyfinServerDiscoveryService {
+  /**
+   * Discovers Jellyfin servers on the local network.
+   *
+   * @param timeoutMs How long to listen for server responses.
+   * @return A [Flow] of discovered servers.
+   */
+  fun discoverServers(
+    timeoutMs: Long = DEFAULT_DISCOVERY_TIMEOUT_MS,
+  ): Flow<ServerDiscoveryInfo>
+
+  /**
+   * Connects to a server by URL, validating the URL and checking version compatibility.
+   *
+   * This method:
+   * 1. Validates and normalizes the URL
+   * 2. Connects to the server and retrieves public system info
+   * 3. Checks server version compatibility
+   * 4. Returns a [ServerConnectionInfo] with all details
+   *
+   * @param serverUrl The server URL (may or may not include scheme).
+   * @return A [JellyfinResult] containing the [ServerConnectionInfo].
+   */
+  suspend fun connectToServer(serverUrl: String): JellyfinResult<ServerConnectionInfo>
+
+  /**
+   * Connects to a previously discovered server.
+   *
+   * @param discoveryInfo The server info from network discovery.
+   * @return A [JellyfinResult] containing the [ServerConnectionInfo].
+   */
+  suspend fun connectToDiscoveredServer(
+    discoveryInfo: ServerDiscoveryInfo,
+  ): JellyfinResult<ServerConnectionInfo>
+
+  companion object {
+    const val DEFAULT_DISCOVERY_TIMEOUT_MS = 3_000L
+  }
+}

--- a/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/ServerConnectionInfo.kt
+++ b/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/ServerConnectionInfo.kt
@@ -1,0 +1,18 @@
+package com.eygraber.jellyfin.services.sdk
+
+import com.eygraber.jellyfin.sdk.core.model.PublicSystemInfo
+
+/**
+ * Information about a successfully connected Jellyfin server.
+ *
+ * Contains the server's public info, normalized URL, and compatibility status.
+ *
+ * @param serverUrl The normalized URL used to connect to the server.
+ * @param systemInfo The server's public system information.
+ * @param isVersionCompatible Whether the server version meets minimum requirements.
+ */
+data class ServerConnectionInfo(
+  val serverUrl: String,
+  val systemInfo: PublicSystemInfo,
+  val isVersionCompatible: Boolean,
+)


### PR DESCRIPTION
## Summary

- Add `ServerUrlValidator` with URL normalization, HTTPS enforcement, and format validation
- Add `ServerVersionValidator` for minimum server version (10.8.0) compatibility checking
- Create `JellyfinServerDiscoveryService` interface and `DefaultJellyfinServerDiscoveryService` impl to orchestrate discovery, URL validation, server connection, and version checking
- Add `ServerConnectionInfo` data class containing connection details and compatibility status
- UDP broadcast discovery is stubbed (returns empty flow) pending platform-specific implementations
- Comprehensive unit tests for validators (17 tests) and discovery service (9 tests)

## Test plan

- [x] `ServerUrlValidatorTest` - empty, blank, valid HTTPS, with port, with path, without scheme, HTTP insecure, invalid format, IP address, localhost, normalize cases
- [x] `ServerVersionValidatorTest` - null, empty, invalid format, compatible versions (10.8+, 11.0), incompatible versions (10.7, 9.x), extra version parts
- [x] `DefaultJellyfinServerDiscoveryServiceTest` - valid URL, URL normalization, empty URL error, HTTP error, incompatible version, server error propagation, discovered server delegation, trailing slash, unknown version
- [x] `./check` passes (lint, detekt, tests, konsist, licensee)

🤖 Generated with [Claude Code](https://claude.com/claude-code)