### PR TITLE
#39 Add continue watching section with progress indicators

### DIFF
--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
@@ -27,5 +27,8 @@ internal object JellyfinNavigators {
     backStack: NavBackStack<NavKey>,
   ) = HomeNavigator(
     onNavigateBack = { backStack.removeLastOrNull() },
+    onNavigateToItemDetail = { itemId ->
+      backStack.add(JellyfinNavKeys.ComingSoon("Item Detail ($itemId)"))
+    },
   )
 }

--- a/screens/home/build.gradle.kts
+++ b/screens/home/build.gradle.kts
@@ -35,10 +35,18 @@ kotlin {
       implementation(libs.bundles.test.paparazzi)
     }
 
+    commonTest.dependencies {
+      implementation(kotlin("test"))
+
+      implementation(libs.test.kotest.assertions.core)
+      implementation(libs.test.kotlinx.coroutines)
+    }
+
     commonMain.dependencies {
       api(projects.di)
 
       implementation(projects.domain.session.public)
+      implementation(projects.services.sdk.public)
 
       implementation(projects.ui.compose)
       implementation(projects.ui.material)

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
@@ -6,12 +6,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.domain.session.SessionManager
 import com.eygraber.jellyfin.domain.session.SessionState
+import com.eygraber.jellyfin.screens.home.model.ContinueWatchingModel
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
 
 @Inject
 class HomeCompositor(
   private val sessionManager: SessionManager,
+  private val navigator: HomeNavigator,
+  private val continueWatchingModel: ContinueWatchingModel,
 ) : ViceCompositor<HomeIntent, HomeViewState> {
   private var isLoading by mutableStateOf(true)
   private var isRefreshing by mutableStateOf(false)
@@ -28,11 +31,14 @@ class HomeCompositor(
       -> ""
     }
 
+    val continueWatchingState = continueWatchingModel.currentState()
+
     return HomeViewState(
       userName = userName,
       isLoading = isLoading,
       error = error,
       isRefreshing = isRefreshing,
+      continueWatchingState = continueWatchingState,
     )
   }
 
@@ -40,6 +46,7 @@ class HomeCompositor(
     when(intent) {
       HomeIntent.Refresh -> refresh()
       HomeIntent.RetryLoad -> retryLoad()
+      is HomeIntent.ContinueWatchingItemClicked -> navigator.navigateToItemDetail(intent.itemId)
     }
   }
 
@@ -51,6 +58,8 @@ class HomeCompositor(
     if(!isValid) {
       error = HomeError.Network()
     }
+
+    continueWatchingModel.refresh()
 
     isRefreshing = false
   }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
@@ -3,4 +3,5 @@ package com.eygraber.jellyfin.screens.home
 sealed interface HomeIntent {
   data object Refresh : HomeIntent
   data object RetryLoad : HomeIntent
+  data class ContinueWatchingItemClicked(val itemId: String) : HomeIntent
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeNavigator.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeNavigator.kt
@@ -2,8 +2,13 @@ package com.eygraber.jellyfin.screens.home
 
 class HomeNavigator(
   private val onNavigateBack: () -> Unit,
+  private val onNavigateToItemDetail: (itemId: String) -> Unit,
 ) {
   fun navigateBack() {
     onNavigateBack()
+  }
+
+  fun navigateToItemDetail(itemId: String) {
+    onNavigateToItemDetail(itemId)
   }
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,6 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.screens.home.components.ContinueWatchingLoading
+import com.eygraber.jellyfin.screens.home.components.ContinueWatchingRow
 import com.eygraber.jellyfin.ui.compose.PreviewJellyfinScreen
 import com.eygraber.jellyfin.ui.material.theme.JellyfinPreviewTheme
 import com.eygraber.jellyfin.ui.material.theme.JellyfinTheme
@@ -60,7 +64,10 @@ internal fun HomeView(
             error = state.error,
             onRetry = { onIntent(HomeIntent.RetryLoad) },
           )
-          else -> HomeContent(state = state)
+          else -> HomeContent(
+            state = state,
+            onIntent = onIntent,
+          )
         }
       }
     }
@@ -101,18 +108,41 @@ private fun ErrorContent(
   }
 }
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
-private fun HomeContent(state: HomeViewState) {
-  Box(
+private fun HomeContent(
+  state: HomeViewState,
+  onIntent: (HomeIntent) -> Unit,
+) {
+  Column(
     modifier = Modifier
       .fillMaxSize()
-      .padding(16.dp),
+      .verticalScroll(rememberScrollState()),
   ) {
-    Text(
-      text = "Content coming soon",
-      style = MaterialTheme.typography.bodyLarge,
+    Spacer(modifier = Modifier.height(8.dp))
+
+    ContinueWatchingSection(
+      state = state.continueWatchingState,
+      onItemClick = { itemId -> onIntent(HomeIntent.ContinueWatchingItemClicked(itemId)) },
     )
+  }
+}
+
+@Composable
+private fun ContinueWatchingSection(
+  state: ContinueWatchingState,
+  onItemClick: (itemId: String) -> Unit,
+) {
+  when(state) {
+    is ContinueWatchingState.Loading -> ContinueWatchingLoading()
+
+    is ContinueWatchingState.Loaded -> ContinueWatchingRow(
+      items = state.items,
+      onItemClick = onItemClick,
+    )
+
+    is ContinueWatchingState.Empty,
+    is ContinueWatchingState.Error,
+    -> Unit
   }
 }
 
@@ -149,6 +179,75 @@ private fun HomeContentPreview() {
       state = HomeViewState(
         userName = "TestUser",
         isLoading = false,
+      ),
+      onIntent = {},
+    )
+  }
+}
+
+@PreviewJellyfinScreen
+@Composable
+private fun HomeContinueWatchingPreview() {
+  JellyfinPreviewTheme {
+    HomeView(
+      state = HomeViewState(
+        userName = "TestUser",
+        isLoading = false,
+        continueWatchingState = ContinueWatchingState.Loaded(
+          items = listOf(
+            ContinueWatchingItem(
+              id = "1",
+              name = "The Dark Knight",
+              type = "Movie",
+              seriesName = null,
+              seasonName = null,
+              indexNumber = null,
+              parentIndexNumber = null,
+              progressPercent = 0.45F,
+              imageUrl = "",
+              backdropImageUrl = null,
+            ),
+            ContinueWatchingItem(
+              id = "2",
+              name = "Ozymandias",
+              type = "Episode",
+              seriesName = "Breaking Bad",
+              seasonName = "Season 5",
+              indexNumber = 14,
+              parentIndexNumber = 5,
+              progressPercent = 0.72F,
+              imageUrl = "",
+              backdropImageUrl = null,
+            ),
+            ContinueWatchingItem(
+              id = "3",
+              name = "Battle of the Bastards",
+              type = "Episode",
+              seriesName = "Game of Thrones",
+              seasonName = "Season 6",
+              indexNumber = 9,
+              parentIndexNumber = 6,
+              progressPercent = 0.15F,
+              imageUrl = "",
+              backdropImageUrl = null,
+            ),
+          ),
+        ),
+      ),
+      onIntent = {},
+    )
+  }
+}
+
+@PreviewJellyfinScreen
+@Composable
+private fun HomeContinueWatchingEmptyPreview() {
+  JellyfinPreviewTheme {
+    HomeView(
+      state = HomeViewState(
+        userName = "TestUser",
+        isLoading = false,
+        continueWatchingState = ContinueWatchingState.Empty,
       ),
       onIntent = {},
     )

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
@@ -8,6 +8,7 @@ data class HomeViewState(
   val isLoading: Boolean = true,
   val error: HomeError? = null,
   val isRefreshing: Boolean = false,
+  val continueWatchingState: ContinueWatchingState = ContinueWatchingState.Loading,
 ) {
   companion object {
     val Loading = HomeViewState(isLoading = true)
@@ -20,4 +21,44 @@ sealed interface HomeError {
 
   data class Network(override val message: String = "Unable to connect to server") : HomeError
   data class Generic(override val message: String = "Something went wrong") : HomeError
+}
+
+@Immutable
+sealed interface ContinueWatchingState {
+  data object Loading : ContinueWatchingState
+  data object Empty : ContinueWatchingState
+  data object Error : ContinueWatchingState
+
+  data class Loaded(
+    val items: List<ContinueWatchingItem>,
+  ) : ContinueWatchingState
+}
+
+@Immutable
+data class ContinueWatchingItem(
+  val id: String,
+  val name: String,
+  val type: String,
+  val seriesName: String?,
+  val seasonName: String?,
+  val indexNumber: Int?,
+  val parentIndexNumber: Int?,
+  val progressPercent: Float,
+  val imageUrl: String,
+  val backdropImageUrl: String?,
+) {
+  val displayName: String
+    get() = when {
+      seriesName != null && parentIndexNumber != null && indexNumber != null ->
+        "$seriesName - S$parentIndexNumber:E$indexNumber"
+
+      seriesName != null -> "$seriesName - $name"
+      else -> name
+    }
+
+  val subtitle: String?
+    get() = when {
+      seriesName != null -> name
+      else -> null
+    }
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/ContinueWatchingLoading.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/ContinueWatchingLoading.kt
@@ -1,0 +1,83 @@
+package com.eygraber.jellyfin.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun ContinueWatchingLoading(
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier = modifier) {
+    Text(
+      text = "Continue Watching",
+      style = MaterialTheme.typography.titleMedium,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    LazyRow(
+      contentPadding = PaddingValues(horizontal = 16.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+      userScrollEnabled = false,
+    ) {
+      items(PlaceholderCount) {
+        Card(
+          modifier = Modifier.width(placeholderCardWidth),
+        ) {
+          Column {
+            Box(
+              modifier = Modifier
+                .fillMaxWidth()
+                .height(placeholderImageHeight)
+                .clip(MaterialTheme.shapes.medium)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+
+            Box(
+              modifier = Modifier
+                .fillMaxWidth()
+                .height(placeholderProgressHeight)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+
+            Column(
+              modifier = Modifier.padding(8.dp),
+            ) {
+              Box(
+                modifier = Modifier
+                  .fillMaxWidth(PlaceholderTextWidthFraction)
+                  .height(placeholderTextHeight)
+                  .clip(MaterialTheme.shapes.small)
+                  .background(MaterialTheme.colorScheme.surfaceVariant),
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+private const val PlaceholderCount = 4
+private val placeholderCardWidth = 160.dp
+private val placeholderImageHeight = 90.dp
+private val placeholderProgressHeight = 4.dp
+private val placeholderTextHeight = 12.dp
+private const val PlaceholderTextWidthFraction = 0.7F

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/ContinueWatchingRow.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/ContinueWatchingRow.kt
@@ -1,0 +1,48 @@
+package com.eygraber.jellyfin.screens.home.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.screens.home.ContinueWatchingItem
+
+@Composable
+internal fun ContinueWatchingRow(
+  items: List<ContinueWatchingItem>,
+  onItemClick: (itemId: String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier = modifier) {
+    Text(
+      text = "Continue Watching",
+      style = MaterialTheme.typography.titleMedium,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    LazyRow(
+      contentPadding = PaddingValues(horizontal = 16.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      items(
+        items = items,
+        key = { it.id },
+      ) { item ->
+        MediaCardWithProgress(
+          item = item,
+          onClick = { onItemClick(item.id) },
+        )
+      }
+    }
+  }
+}

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/MediaCardWithProgress.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/MediaCardWithProgress.kt
@@ -1,0 +1,82 @@
+package com.eygraber.jellyfin.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.screens.home.ContinueWatchingItem
+
+@Composable
+internal fun MediaCardWithProgress(
+  item: ContinueWatchingItem,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Card(
+    onClick = onClick,
+    modifier = modifier.width(cardWidth),
+  ) {
+    Column {
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(cardImageHeight)
+          .clip(MaterialTheme.shapes.medium)
+          .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+      ) {
+        // Placeholder for image loading (Coil integration pending)
+        Text(
+          text = item.name.take(1).uppercase(),
+          style = MaterialTheme.typography.headlineMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
+      LinearProgressIndicator(
+        progress = { item.progressPercent },
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.primary,
+        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+      )
+
+      Column(
+        modifier = Modifier.padding(8.dp),
+      ) {
+        Text(
+          text = item.displayName,
+          style = MaterialTheme.typography.bodySmall,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+
+        val subtitle = item.subtitle
+        if(subtitle != null) {
+          Text(
+            text = subtitle,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+          )
+        }
+      }
+    }
+  }
+}
+
+private val cardWidth = 160.dp
+private val cardImageHeight = 90.dp

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModel.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModel.kt
@@ -1,0 +1,124 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.eygraber.jellyfin.common.isSuccess
+import com.eygraber.jellyfin.screens.home.ContinueWatchingItem
+import com.eygraber.jellyfin.screens.home.ContinueWatchingState
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.vice.ViceSource
+import dev.zacsweers.metro.Inject
+
+@Inject
+class ContinueWatchingModel(
+  private val libraryService: JellyfinLibraryService,
+) : ViceSource<ContinueWatchingState> {
+  private var state by mutableStateOf<ContinueWatchingState>(ContinueWatchingState.Loading)
+
+  internal val stateForTest: ContinueWatchingState get() = state
+
+  @Composable
+  override fun currentState(): ContinueWatchingState {
+    LaunchedEffect(Unit) {
+      load()
+    }
+
+    return state
+  }
+
+  suspend fun refresh() {
+    load()
+  }
+
+  private suspend fun load() {
+    state = ContinueWatchingState.Loading
+
+    val result = libraryService.getResumeItems(
+      limit = RESUME_ITEMS_LIMIT,
+      mediaTypes = listOf("Video"),
+      fields = listOf("PrimaryImageAspectRatio"),
+    )
+
+    state = if(result.isSuccess()) {
+      val items = result.value.items
+        .filter { it.id != null }
+        .map { dto ->
+          val itemId = requireNotNull(dto.id)
+
+          val runTimeTicks = dto.runTimeTicks ?: 0L
+          val positionTicks = dto.userData?.playbackPositionTicks ?: 0L
+          val progressPercent = if(runTimeTicks > 0L) {
+            (positionTicks.toFloat() / runTimeTicks.toFloat()).coerceIn(
+              minimumValue = 0F,
+              maximumValue = 1F,
+            )
+          }
+          else {
+            0F
+          }
+
+          ContinueWatchingItem(
+            id = itemId,
+            name = dto.name.orEmpty(),
+            type = dto.type.orEmpty(),
+            seriesName = dto.seriesName,
+            seasonName = dto.seasonName,
+            indexNumber = dto.indexNumber,
+            parentIndexNumber = dto.parentIndexNumber,
+            progressPercent = progressPercent,
+            imageUrl = libraryService.getImageUrl(
+              itemId = itemId,
+              imageType = ImageType.Primary,
+              maxWidth = IMAGE_MAX_WIDTH,
+              tag = dto.imageTags["Primary"],
+            ),
+            backdropImageUrl = resolveBackdropUrl(dto, itemId),
+          )
+        }
+
+      if(items.isEmpty()) {
+        ContinueWatchingState.Empty
+      }
+      else {
+        ContinueWatchingState.Loaded(items = items)
+      }
+    }
+    else {
+      ContinueWatchingState.Error
+    }
+  }
+
+  private fun resolveBackdropUrl(dto: BaseItemDto, itemId: String): String? {
+    val backdropTag = dto.backdropImageTags.firstOrNull()
+    if(backdropTag != null) {
+      return libraryService.getImageUrl(
+        itemId = itemId,
+        imageType = ImageType.Backdrop,
+        maxWidth = BACKDROP_MAX_WIDTH,
+        tag = backdropTag,
+      )
+    }
+
+    return dto.parentBackdropItemId?.let { parentId ->
+      dto.parentBackdropImageTags.firstOrNull()?.let { parentTag ->
+        libraryService.getImageUrl(
+          itemId = parentId,
+          imageType = ImageType.Backdrop,
+          maxWidth = BACKDROP_MAX_WIDTH,
+          tag = parentTag,
+        )
+      }
+    }
+  }
+
+  companion object {
+    private const val RESUME_ITEMS_LIMIT = 12
+    private const val IMAGE_MAX_WIDTH = 300
+    private const val BACKDROP_MAX_WIDTH = 600
+  }
+}

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/ContinueWatchingItemTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/ContinueWatchingItemTest.kt
@@ -1,0 +1,101 @@
+package com.eygraber.jellyfin.screens.home
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class ContinueWatchingItemTest {
+  @Test
+  fun movie_displayName_shows_name() {
+    val item = createItem(
+      name = "The Dark Knight",
+      type = "Movie",
+    )
+    item.displayName shouldBe "The Dark Knight"
+  }
+
+  @Test
+  fun movie_subtitle_is_null() {
+    val item = createItem(
+      name = "The Dark Knight",
+      type = "Movie",
+    )
+    item.subtitle.shouldBeNull()
+  }
+
+  @Test
+  fun episode_with_series_and_numbers_shows_formatted_displayName() {
+    val item = createItem(
+      name = "Ozymandias",
+      type = "Episode",
+      seriesName = "Breaking Bad",
+      parentIndexNumber = 5,
+      indexNumber = 14,
+    )
+    item.displayName shouldBe "Breaking Bad - S5:E14"
+  }
+
+  @Test
+  fun episode_with_series_and_numbers_shows_episode_name_as_subtitle() {
+    val item = createItem(
+      name = "Ozymandias",
+      type = "Episode",
+      seriesName = "Breaking Bad",
+      parentIndexNumber = 5,
+      indexNumber = 14,
+    )
+    item.subtitle shouldBe "Ozymandias"
+  }
+
+  @Test
+  fun episode_with_series_but_no_numbers_shows_series_dash_name() {
+    val item = createItem(
+      name = "Pilot",
+      type = "Episode",
+      seriesName = "Lost",
+    )
+    item.displayName shouldBe "Lost - Pilot"
+  }
+
+  @Test
+  fun episode_with_series_but_no_numbers_shows_name_as_subtitle() {
+    val item = createItem(
+      name = "Pilot",
+      type = "Episode",
+      seriesName = "Lost",
+    )
+    item.subtitle shouldBe "Pilot"
+  }
+
+  @Test
+  fun episode_with_only_season_number_shows_series_dash_name() {
+    val item = createItem(
+      name = "Episode 1",
+      type = "Episode",
+      seriesName = "Some Show",
+      parentIndexNumber = 3,
+    )
+    item.displayName shouldBe "Some Show - Episode 1"
+  }
+
+  private fun createItem(
+    name: String,
+    type: String,
+    seriesName: String? = null,
+    seasonName: String? = null,
+    indexNumber: Int? = null,
+    parentIndexNumber: Int? = null,
+    progressPercent: Float = 0.5F,
+  ) = ContinueWatchingItem(
+    id = "test-id",
+    name = name,
+    type = type,
+    seriesName = seriesName,
+    seasonName = seasonName,
+    indexNumber = indexNumber,
+    parentIndexNumber = parentIndexNumber,
+    progressPercent = progressPercent,
+    imageUrl = "https://example.com/image.jpg",
+    backdropImageUrl = null,
+  )
+}

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModelTest.kt
@@ -1,0 +1,265 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.screens.home.ContinueWatchingState
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.sdk.core.model.ItemsResult
+import com.eygraber.jellyfin.sdk.core.model.UserItemDataDto
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class ContinueWatchingModelTest {
+  private lateinit var fakeLibraryService: FakeJellyfinLibraryService
+  private lateinit var model: ContinueWatchingModel
+
+  @BeforeTest
+  fun setUp() {
+    fakeLibraryService = FakeJellyfinLibraryService()
+    model = ContinueWatchingModel(libraryService = fakeLibraryService)
+  }
+
+  @Test
+  fun refresh_with_items_returns_loaded_state() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            createBaseItemDto(
+              id = "movie-1",
+              name = "Test Movie",
+              type = "Movie",
+              runTimeTicks = 100_000L,
+              playbackPositionTicks = 50_000L,
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val state = model.stateForTest
+      val loaded = state.shouldBeInstanceOf<ContinueWatchingState.Loaded>()
+      loaded.items.size shouldBe 1
+      loaded.items[0].id shouldBe "movie-1"
+      loaded.items[0].name shouldBe "Test Movie"
+      loaded.items[0].progressPercent shouldBe 0.5F
+    }
+  }
+
+  @Test
+  fun refresh_with_empty_items_returns_empty_state() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Success(
+        ItemsResult(items = emptyList(), totalRecordCount = 0),
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<ContinueWatchingState.Empty>()
+    }
+  }
+
+  @Test
+  fun refresh_with_error_returns_error_state() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Error(
+        message = "Network error",
+        isEphemeral = true,
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<ContinueWatchingState.Error>()
+    }
+  }
+
+  @Test
+  fun items_without_id_are_filtered_out() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            createBaseItemDto(
+              id = null,
+              name = "No ID Item",
+              type = "Movie",
+            ),
+            createBaseItemDto(
+              id = "valid-id",
+              name = "Valid Item",
+              type = "Movie",
+            ),
+          ),
+          totalRecordCount = 2,
+        ),
+      )
+
+      model.refresh()
+
+      val state = model.stateForTest
+      val loaded = state.shouldBeInstanceOf<ContinueWatchingState.Loaded>()
+      loaded.items.size shouldBe 1
+      loaded.items[0].id shouldBe "valid-id"
+    }
+  }
+
+  @Test
+  fun progress_is_clamped_between_0_and_1() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            createBaseItemDto(
+              id = "item-1",
+              name = "Item",
+              type = "Movie",
+              runTimeTicks = 100L,
+              playbackPositionTicks = 200L,
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<ContinueWatchingState.Loaded>()
+      loaded.items[0].progressPercent shouldBe 1F
+    }
+  }
+
+  @Test
+  fun zero_runtime_gives_zero_progress() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            createBaseItemDto(
+              id = "item-1",
+              name = "Item",
+              type = "Movie",
+              runTimeTicks = 0L,
+              playbackPositionTicks = 50L,
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<ContinueWatchingState.Loaded>()
+      loaded.items[0].progressPercent shouldBe 0F
+    }
+  }
+
+  @Test
+  fun episode_items_include_series_info() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            createBaseItemDto(
+              id = "ep-1",
+              name = "Ozymandias",
+              type = "Episode",
+              seriesName = "Breaking Bad",
+              seasonName = "Season 5",
+              indexNumber = 14,
+              parentIndexNumber = 5,
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<ContinueWatchingState.Loaded>()
+      val item = loaded.items[0]
+      item.seriesName shouldBe "Breaking Bad"
+      item.seasonName shouldBe "Season 5"
+      item.indexNumber shouldBe 14
+      item.parentIndexNumber shouldBe 5
+    }
+  }
+
+  @Test
+  fun all_items_without_id_results_in_empty_state() {
+    runTest {
+      fakeLibraryService.resumeItemsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            createBaseItemDto(id = null, name = "Item 1", type = "Movie"),
+            createBaseItemDto(id = null, name = "Item 2", type = "Movie"),
+          ),
+          totalRecordCount = 2,
+        ),
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<ContinueWatchingState.Empty>()
+    }
+  }
+
+  private fun createBaseItemDto(
+    id: String?,
+    name: String,
+    type: String,
+    runTimeTicks: Long? = null,
+    playbackPositionTicks: Long = 0L,
+    seriesName: String? = null,
+    seasonName: String? = null,
+    indexNumber: Int? = null,
+    parentIndexNumber: Int? = null,
+  ) = BaseItemDto(
+    id = id,
+    name = name,
+    type = type,
+    runTimeTicks = runTimeTicks,
+    userData = UserItemDataDto(
+      playbackPositionTicks = playbackPositionTicks,
+    ),
+    seriesName = seriesName,
+    seasonName = seasonName,
+    indexNumber = indexNumber,
+    parentIndexNumber = parentIndexNumber,
+  )
+}
+
+private class FakeJellyfinLibraryService : JellyfinLibraryService {
+  var resumeItemsResult: JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  var latestItemsResult: JellyfinResult<List<BaseItemDto>> = JellyfinResult.Success(emptyList())
+
+  override suspend fun getResumeItems(
+    limit: Int?,
+    mediaTypes: List<String>?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = resumeItemsResult
+
+  override suspend fun getLatestItems(
+    parentId: String?,
+    includeItemTypes: List<String>?,
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<List<BaseItemDto>> = latestItemsResult
+
+  override fun getImageUrl(
+    itemId: String,
+    imageType: ImageType,
+    maxWidth: Int?,
+    maxHeight: Int?,
+    tag: String?,
+    imageIndex: Int?,
+  ): String = "https://example.com/images/$itemId/${imageType.apiValue}"
+}

--- a/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinLibraryService.kt
+++ b/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinLibraryService.kt
@@ -1,0 +1,128 @@
+package com.eygraber.jellyfin.services.sdk.impl
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.sdk.core.JellyfinSdk
+import com.eygraber.jellyfin.sdk.core.api.library.libraryApi
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.sdk.core.model.ItemsResult
+import com.eygraber.jellyfin.services.logging.JellyfinLogger
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.jellyfin.services.sdk.JellyfinSessionManager
+import com.eygraber.jellyfin.services.sdk.toJellyfinResult
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+
+/**
+ * Default implementation of [JellyfinLibraryService].
+ *
+ * Uses the [JellyfinSdk] to access the Jellyfin media library.
+ * Requires an active authenticated session with a valid user ID.
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultJellyfinLibraryService(
+  private val sdk: JellyfinSdk,
+  private val sessionManager: JellyfinSessionManager,
+  private val logger: JellyfinLogger,
+) : JellyfinLibraryService {
+  override suspend fun getResumeItems(
+    limit: Int?,
+    mediaTypes: List<String>?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> {
+    val serverInfo = sessionManager.currentServer.value
+      ?: return JellyfinResult.Error(
+        message = "Not connected to a server",
+        isEphemeral = false,
+      )
+
+    val userId = serverInfo.userId
+      ?: return JellyfinResult.Error(
+        message = "Not authenticated",
+        isEphemeral = false,
+      )
+
+    logger.debug(tag = TAG, message = "Fetching resume items for user: $userId")
+
+    val apiClient = sdk.createApiClient(serverInfo = serverInfo)
+    return try {
+      apiClient.libraryApi.getResumeItems(
+        userId = userId,
+        limit = limit,
+        includeItemTypes = mediaTypes,
+        fields = fields,
+      ).toJellyfinResult()
+    }
+    finally {
+      apiClient.close()
+    }
+  }
+
+  override suspend fun getLatestItems(
+    parentId: String?,
+    includeItemTypes: List<String>?,
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<List<BaseItemDto>> {
+    val serverInfo = sessionManager.currentServer.value
+      ?: return JellyfinResult.Error(
+        message = "Not connected to a server",
+        isEphemeral = false,
+      )
+
+    val userId = serverInfo.userId
+      ?: return JellyfinResult.Error(
+        message = "Not authenticated",
+        isEphemeral = false,
+      )
+
+    logger.debug(tag = TAG, message = "Fetching latest items for user: $userId")
+
+    val apiClient = sdk.createApiClient(serverInfo = serverInfo)
+    return try {
+      apiClient.libraryApi.getLatestItems(
+        userId = userId,
+        parentId = parentId,
+        includeItemTypes = includeItemTypes,
+        limit = limit,
+        fields = fields,
+      ).toJellyfinResult()
+    }
+    finally {
+      apiClient.close()
+    }
+  }
+
+  override fun getImageUrl(
+    itemId: String,
+    imageType: ImageType,
+    maxWidth: Int?,
+    maxHeight: Int?,
+    tag: String?,
+    imageIndex: Int?,
+  ): String {
+    val serverInfo = sessionManager.currentServer.value
+      ?: return ""
+
+    val apiClient = sdk.createApiClient(serverInfo = serverInfo)
+    return try {
+      apiClient.libraryApi.getImageUrl(
+        itemId = itemId,
+        imageType = imageType,
+        maxWidth = maxWidth,
+        maxHeight = maxHeight,
+        tag = tag,
+        imageIndex = imageIndex,
+      )
+    }
+    finally {
+      apiClient.close()
+    }
+  }
+
+  companion object {
+    private const val TAG = "JellyfinLibraryService"
+  }
+}

--- a/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinLibraryService.kt
+++ b/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinLibraryService.kt
@@ -1,0 +1,66 @@
+package com.eygraber.jellyfin.services.sdk
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.sdk.core.model.ItemsResult
+
+/**
+ * Service for accessing the Jellyfin media library.
+ *
+ * Provides operations to browse, search, and retrieve media items
+ * from the connected Jellyfin server.
+ */
+interface JellyfinLibraryService {
+  /**
+   * Gets items that the user has started but not finished watching.
+   *
+   * Results are sorted by last played date (most recent first) by the server.
+   *
+   * @param limit Maximum number of items to return.
+   * @param mediaTypes Filter by media types (e.g., "Video").
+   * @param fields Additional fields to include in the response.
+   * @return A [JellyfinResult] containing the [ItemsResult].
+   */
+  suspend fun getResumeItems(
+    limit: Int? = null,
+    mediaTypes: List<String>? = null,
+    fields: List<String>? = null,
+  ): JellyfinResult<ItemsResult>
+
+  /**
+   * Gets the latest items added to the library.
+   *
+   * @param parentId Filter by parent item ID (e.g., library ID).
+   * @param includeItemTypes Filter by item types.
+   * @param limit Maximum number of items to return.
+   * @param fields Additional fields to include in the response.
+   * @return A [JellyfinResult] containing a list of [BaseItemDto].
+   */
+  suspend fun getLatestItems(
+    parentId: String? = null,
+    includeItemTypes: List<String>? = null,
+    limit: Int? = null,
+    fields: List<String>? = null,
+  ): JellyfinResult<List<BaseItemDto>>
+
+  /**
+   * Generates the URL for an item image.
+   *
+   * @param itemId The item ID.
+   * @param imageType The type of image.
+   * @param maxWidth Maximum width in pixels.
+   * @param maxHeight Maximum height in pixels.
+   * @param tag The image tag for cache busting.
+   * @param imageIndex The image index (for backdrop images).
+   * @return The fully qualified image URL.
+   */
+  fun getImageUrl(
+    itemId: String,
+    imageType: ImageType = ImageType.Primary,
+    maxWidth: Int? = null,
+    maxHeight: Int? = null,
+    tag: String? = null,
+    imageIndex: Int? = null,
+  ): String
+}


### PR DESCRIPTION
## Summary
- Adds `JellyfinLibraryService` interface and `DefaultJellyfinLibraryService` implementation for accessing resume items, latest items, and image URLs from the Jellyfin server
- Implements `ContinueWatchingModel` ViceSource that fetches in-progress media items with progress calculation
- Creates `ContinueWatchingRow` and `MediaCardWithProgress` UI components with horizontal scrollable layout and `LinearProgressIndicator` overlay
- Integrates continue watching section into `HomeCompositor` and `HomeView` with loading, loaded, empty, and error states
- Adds item click navigation (routed to "Coming Soon" dialog placeholder)

## Test plan
- [x] `ContinueWatchingItemTest` - 7 tests covering display name formatting for movies and episodes
- [x] `ContinueWatchingModelTest` - 8 tests covering loaded/empty/error states, progress clamping, null ID filtering, and episode series info mapping
- [x] `./check` passes (lint, detekt, tests, konsist)
- [ ] Visual verification of continue watching row with populated items
- [ ] Verify pull-to-refresh reloads continue watching data
- [ ] Verify empty state shows nothing (no section header)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)