### PR TITLE
Add next up and recently added sections to home screen

### DIFF
--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.domain.session.SessionManager
 import com.eygraber.jellyfin.domain.session.SessionState
 import com.eygraber.jellyfin.screens.home.model.ContinueWatchingModel
+import com.eygraber.jellyfin.screens.home.model.NextUpModel
+import com.eygraber.jellyfin.screens.home.model.RecentlyAddedModel
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
 
@@ -15,6 +17,8 @@ class HomeCompositor(
   private val sessionManager: SessionManager,
   private val navigator: HomeNavigator,
   private val continueWatchingModel: ContinueWatchingModel,
+  private val nextUpModel: NextUpModel,
+  private val recentlyAddedModel: RecentlyAddedModel,
 ) : ViceCompositor<HomeIntent, HomeViewState> {
   private var isLoading by mutableStateOf(true)
   private var isRefreshing by mutableStateOf(false)
@@ -32,6 +36,8 @@ class HomeCompositor(
     }
 
     val continueWatchingState = continueWatchingModel.currentState()
+    val nextUpState = nextUpModel.currentState()
+    val recentlyAddedState = recentlyAddedModel.currentState()
 
     return HomeViewState(
       userName = userName,
@@ -39,6 +45,8 @@ class HomeCompositor(
       error = error,
       isRefreshing = isRefreshing,
       continueWatchingState = continueWatchingState,
+      nextUpState = nextUpState,
+      recentlyAddedState = recentlyAddedState,
     )
   }
 
@@ -47,6 +55,8 @@ class HomeCompositor(
       HomeIntent.Refresh -> refresh()
       HomeIntent.RetryLoad -> retryLoad()
       is HomeIntent.ContinueWatchingItemClicked -> navigator.navigateToItemDetail(intent.itemId)
+      is HomeIntent.NextUpItemClicked -> navigator.navigateToItemDetail(intent.itemId)
+      is HomeIntent.RecentlyAddedItemClicked -> navigator.navigateToItemDetail(intent.itemId)
     }
   }
 
@@ -60,6 +70,8 @@ class HomeCompositor(
     }
 
     continueWatchingModel.refresh()
+    nextUpModel.refresh()
+    recentlyAddedModel.refresh()
 
     isRefreshing = false
   }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
@@ -4,4 +4,6 @@ sealed interface HomeIntent {
   data object Refresh : HomeIntent
   data object RetryLoad : HomeIntent
   data class ContinueWatchingItemClicked(val itemId: String) : HomeIntent
+  data class NextUpItemClicked(val itemId: String) : HomeIntent
+  data class RecentlyAddedItemClicked(val itemId: String) : HomeIntent
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.eygraber.jellyfin.screens.home.components.ContinueWatchingLoading
 import com.eygraber.jellyfin.screens.home.components.ContinueWatchingRow
+import com.eygraber.jellyfin.screens.home.components.NextUpRow
+import com.eygraber.jellyfin.screens.home.components.RecentlyAddedSection
 import com.eygraber.jellyfin.ui.compose.PreviewJellyfinScreen
 import com.eygraber.jellyfin.ui.material.theme.JellyfinPreviewTheme
 import com.eygraber.jellyfin.ui.material.theme.JellyfinTheme
@@ -124,6 +126,18 @@ private fun HomeContent(
       state = state.continueWatchingState,
       onItemClick = { itemId -> onIntent(HomeIntent.ContinueWatchingItemClicked(itemId)) },
     )
+
+    NextUpSection(
+      state = state.nextUpState,
+      onItemClick = { itemId -> onIntent(HomeIntent.NextUpItemClicked(itemId)) },
+    )
+
+    RecentlyAddedHomeSection(
+      state = state.recentlyAddedState,
+      onItemClick = { itemId -> onIntent(HomeIntent.RecentlyAddedItemClicked(itemId)) },
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
   }
 }
 
@@ -142,6 +156,50 @@ private fun ContinueWatchingSection(
 
     is ContinueWatchingState.Empty,
     is ContinueWatchingState.Error,
+    -> Unit
+  }
+}
+
+@Composable
+private fun NextUpSection(
+  state: NextUpState,
+  onItemClick: (itemId: String) -> Unit,
+) {
+  when(state) {
+    is NextUpState.Loading -> Unit
+
+    is NextUpState.Loaded -> {
+      Spacer(modifier = Modifier.height(16.dp))
+      NextUpRow(
+        items = state.items,
+        onItemClick = onItemClick,
+      )
+    }
+
+    is NextUpState.Empty,
+    is NextUpState.Error,
+    -> Unit
+  }
+}
+
+@Composable
+private fun RecentlyAddedHomeSection(
+  state: RecentlyAddedState,
+  onItemClick: (itemId: String) -> Unit,
+) {
+  when(state) {
+    is RecentlyAddedState.Loading -> Unit
+
+    is RecentlyAddedState.Loaded -> {
+      Spacer(modifier = Modifier.height(16.dp))
+      RecentlyAddedSection(
+        items = state.items,
+        onItemClick = onItemClick,
+      )
+    }
+
+    is RecentlyAddedState.Empty,
+    is RecentlyAddedState.Error,
     -> Unit
   }
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
@@ -9,6 +9,8 @@ data class HomeViewState(
   val error: HomeError? = null,
   val isRefreshing: Boolean = false,
   val continueWatchingState: ContinueWatchingState = ContinueWatchingState.Loading,
+  val nextUpState: NextUpState = NextUpState.Loading,
+  val recentlyAddedState: RecentlyAddedState = RecentlyAddedState.Loading,
 ) {
   companion object {
     val Loading = HomeViewState(isLoading = true)
@@ -62,3 +64,58 @@ data class ContinueWatchingItem(
       else -> null
     }
 }
+
+@Immutable
+sealed interface NextUpState {
+  data object Loading : NextUpState
+  data object Empty : NextUpState
+  data object Error : NextUpState
+
+  data class Loaded(
+    val items: List<NextUpItem>,
+  ) : NextUpState
+}
+
+@Immutable
+data class NextUpItem(
+  val id: String,
+  val name: String,
+  val seriesName: String?,
+  val seasonName: String?,
+  val indexNumber: Int?,
+  val parentIndexNumber: Int?,
+  val imageUrl: String,
+  val backdropImageUrl: String?,
+) {
+  val displayName: String
+    get() = when {
+      seriesName != null && parentIndexNumber != null && indexNumber != null ->
+        "S$parentIndexNumber:E$indexNumber"
+
+      else -> name
+    }
+
+  val subtitle: String
+    get() = name
+}
+
+@Immutable
+sealed interface RecentlyAddedState {
+  data object Loading : RecentlyAddedState
+  data object Empty : RecentlyAddedState
+  data object Error : RecentlyAddedState
+
+  data class Loaded(
+    val items: List<RecentlyAddedItem>,
+  ) : RecentlyAddedState
+}
+
+@Immutable
+data class RecentlyAddedItem(
+  val id: String,
+  val name: String,
+  val type: String,
+  val productionYear: Int?,
+  val imageUrl: String,
+  val seriesName: String?,
+)

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/NextUpRow.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/NextUpRow.kt
@@ -1,0 +1,109 @@
+package com.eygraber.jellyfin.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.screens.home.NextUpItem
+
+@Composable
+internal fun NextUpRow(
+  items: List<NextUpItem>,
+  onItemClick: (itemId: String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier = modifier) {
+    Text(
+      text = "Next Up",
+      style = MaterialTheme.typography.titleMedium,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    LazyRow(
+      contentPadding = PaddingValues(horizontal = 16.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      items(
+        items = items,
+        key = { it.id },
+      ) { item ->
+        NextUpCard(
+          item = item,
+          onClick = { onItemClick(item.id) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun NextUpCard(
+  item: NextUpItem,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Card(
+    onClick = onClick,
+    modifier = modifier.width(nextUpCardWidth),
+  ) {
+    Column {
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(nextUpImageHeight)
+          .clip(MaterialTheme.shapes.medium)
+          .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = item.name.take(1).uppercase(),
+          style = MaterialTheme.typography.headlineMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
+      Column(
+        modifier = Modifier.padding(8.dp),
+      ) {
+        item.seriesName?.let { seriesName ->
+          Text(
+            text = seriesName,
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+          )
+        }
+
+        Text(
+          text = "${item.displayName} - ${item.subtitle}",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+      }
+    }
+  }
+}
+
+private val nextUpCardWidth = 180.dp
+private val nextUpImageHeight = 100.dp

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/RecentlyAddedSection.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/RecentlyAddedSection.kt
@@ -1,0 +1,107 @@
+package com.eygraber.jellyfin.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.screens.home.RecentlyAddedItem
+
+@Composable
+internal fun RecentlyAddedSection(
+  items: List<RecentlyAddedItem>,
+  onItemClick: (itemId: String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier = modifier) {
+    Text(
+      text = "Recently Added",
+      style = MaterialTheme.typography.titleMedium,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    LazyRow(
+      contentPadding = PaddingValues(horizontal = 16.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      items(
+        items = items,
+        key = { it.id },
+      ) { item ->
+        RecentlyAddedCard(
+          item = item,
+          onClick = { onItemClick(item.id) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun RecentlyAddedCard(
+  item: RecentlyAddedItem,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Card(
+    onClick = onClick,
+    modifier = modifier.width(recentlyAddedCardWidth),
+  ) {
+    Column {
+      Box(
+        modifier = Modifier
+          .width(recentlyAddedCardWidth)
+          .height(recentlyAddedImageHeight)
+          .clip(MaterialTheme.shapes.medium)
+          .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = item.name.take(1).uppercase(),
+          style = MaterialTheme.typography.headlineMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
+      Column(
+        modifier = Modifier.padding(8.dp),
+      ) {
+        Text(
+          text = item.seriesName ?: item.name,
+          style = MaterialTheme.typography.bodySmall,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+
+        val yearText = item.productionYear?.toString()
+        if(yearText != null) {
+          Text(
+            text = yearText,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+    }
+  }
+}
+
+private val recentlyAddedCardWidth = 120.dp
+private val recentlyAddedImageHeight = 180.dp

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/NextUpModel.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/NextUpModel.kt
@@ -1,0 +1,111 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.eygraber.jellyfin.common.isSuccess
+import com.eygraber.jellyfin.screens.home.NextUpItem
+import com.eygraber.jellyfin.screens.home.NextUpState
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.vice.ViceSource
+import dev.zacsweers.metro.Inject
+
+@Inject
+class NextUpModel(
+  private val libraryService: JellyfinLibraryService,
+) : ViceSource<NextUpState> {
+  private var state by mutableStateOf<NextUpState>(NextUpState.Loading)
+
+  internal val stateForTest: NextUpState get() = state
+
+  @Composable
+  override fun currentState(): NextUpState {
+    LaunchedEffect(Unit) {
+      load()
+    }
+
+    return state
+  }
+
+  suspend fun refresh() {
+    load()
+  }
+
+  private suspend fun load() {
+    state = NextUpState.Loading
+
+    val result = libraryService.getNextUpEpisodes(
+      limit = NEXT_UP_LIMIT,
+      fields = listOf("PrimaryImageAspectRatio", "Overview"),
+    )
+
+    state = if(result.isSuccess()) {
+      val items = result.value.items
+        .filter { it.id != null }
+        .map { dto -> mapToNextUpItem(dto) }
+
+      if(items.isEmpty()) {
+        NextUpState.Empty
+      }
+      else {
+        NextUpState.Loaded(items = items)
+      }
+    }
+    else {
+      NextUpState.Error
+    }
+  }
+
+  private fun mapToNextUpItem(dto: BaseItemDto): NextUpItem {
+    val itemId = requireNotNull(dto.id)
+
+    return NextUpItem(
+      id = itemId,
+      name = dto.name.orEmpty(),
+      seriesName = dto.seriesName,
+      seasonName = dto.seasonName,
+      indexNumber = dto.indexNumber,
+      parentIndexNumber = dto.parentIndexNumber,
+      imageUrl = libraryService.getImageUrl(
+        itemId = itemId,
+        imageType = ImageType.Primary,
+        maxWidth = IMAGE_MAX_WIDTH,
+        tag = dto.imageTags["Primary"],
+      ),
+      backdropImageUrl = resolveBackdropUrl(dto, itemId),
+    )
+  }
+
+  private fun resolveBackdropUrl(dto: BaseItemDto, itemId: String): String? {
+    val backdropTag = dto.backdropImageTags.firstOrNull()
+    if(backdropTag != null) {
+      return libraryService.getImageUrl(
+        itemId = itemId,
+        imageType = ImageType.Backdrop,
+        maxWidth = BACKDROP_MAX_WIDTH,
+        tag = backdropTag,
+      )
+    }
+
+    return dto.parentBackdropItemId?.let { parentId ->
+      dto.parentBackdropImageTags.firstOrNull()?.let { parentTag ->
+        libraryService.getImageUrl(
+          itemId = parentId,
+          imageType = ImageType.Backdrop,
+          maxWidth = BACKDROP_MAX_WIDTH,
+          tag = parentTag,
+        )
+      }
+    }
+  }
+
+  companion object {
+    private const val NEXT_UP_LIMIT = 12
+    private const val IMAGE_MAX_WIDTH = 300
+    private const val BACKDROP_MAX_WIDTH = 600
+  }
+}

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/RecentlyAddedModel.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/RecentlyAddedModel.kt
@@ -1,0 +1,81 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.eygraber.jellyfin.common.isSuccess
+import com.eygraber.jellyfin.screens.home.RecentlyAddedItem
+import com.eygraber.jellyfin.screens.home.RecentlyAddedState
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.vice.ViceSource
+import dev.zacsweers.metro.Inject
+
+@Inject
+class RecentlyAddedModel(
+  private val libraryService: JellyfinLibraryService,
+) : ViceSource<RecentlyAddedState> {
+  private var state by mutableStateOf<RecentlyAddedState>(RecentlyAddedState.Loading)
+
+  internal val stateForTest: RecentlyAddedState get() = state
+
+  @Composable
+  override fun currentState(): RecentlyAddedState {
+    LaunchedEffect(Unit) {
+      load()
+    }
+
+    return state
+  }
+
+  suspend fun refresh() {
+    load()
+  }
+
+  private suspend fun load() {
+    state = RecentlyAddedState.Loading
+
+    val result = libraryService.getLatestItems(
+      limit = RECENTLY_ADDED_LIMIT,
+      fields = listOf("PrimaryImageAspectRatio"),
+    )
+
+    state = if(result.isSuccess()) {
+      val items = result.value
+        .filter { it.id != null }
+        .map { dto ->
+          val itemId = requireNotNull(dto.id)
+          RecentlyAddedItem(
+            id = itemId,
+            name = dto.name.orEmpty(),
+            type = dto.type.orEmpty(),
+            productionYear = dto.productionYear,
+            imageUrl = libraryService.getImageUrl(
+              itemId = itemId,
+              imageType = ImageType.Primary,
+              maxWidth = IMAGE_MAX_WIDTH,
+              tag = dto.imageTags["Primary"],
+            ),
+            seriesName = dto.seriesName,
+          )
+        }
+
+      if(items.isEmpty()) {
+        RecentlyAddedState.Empty
+      }
+      else {
+        RecentlyAddedState.Loaded(items = items)
+      }
+    }
+    else {
+      RecentlyAddedState.Error
+    }
+  }
+
+  companion object {
+    private const val RECENTLY_ADDED_LIMIT = 16
+    private const val IMAGE_MAX_WIDTH = 300
+  }
+}

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModelTest.kt
@@ -241,11 +241,20 @@ private class FakeJellyfinLibraryService : JellyfinLibraryService {
 
   var latestItemsResult: JellyfinResult<List<BaseItemDto>> = JellyfinResult.Success(emptyList())
 
+  var nextUpResult: JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
   override suspend fun getResumeItems(
     limit: Int?,
     mediaTypes: List<String>?,
     fields: List<String>?,
   ): JellyfinResult<ItemsResult> = resumeItemsResult
+
+  override suspend fun getNextUpEpisodes(
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = nextUpResult
 
   override suspend fun getLatestItems(
     parentId: String?,

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/NextUpModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/NextUpModelTest.kt
@@ -1,0 +1,136 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.screens.home.NextUpState
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.sdk.core.model.ItemsResult
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class NextUpModelTest {
+  private lateinit var fakeLibraryService: FakeNextUpLibraryService
+  private lateinit var model: NextUpModel
+
+  @BeforeTest
+  fun setUp() {
+    fakeLibraryService = FakeNextUpLibraryService()
+    model = NextUpModel(libraryService = fakeLibraryService)
+  }
+
+  @Test
+  fun refresh_with_episodes_returns_loaded_state() {
+    runTest {
+      fakeLibraryService.nextUpResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(
+              id = "ep-1",
+              name = "The One Where They All Get Coffee",
+              seriesName = "Friends",
+              seasonName = "Season 3",
+              indexNumber = 5,
+              parentIndexNumber = 3,
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<NextUpState.Loaded>()
+      loaded.items.size shouldBe 1
+      loaded.items[0].id shouldBe "ep-1"
+      loaded.items[0].seriesName shouldBe "Friends"
+      loaded.items[0].indexNumber shouldBe 5
+    }
+  }
+
+  @Test
+  fun refresh_with_empty_returns_empty_state() {
+    runTest {
+      fakeLibraryService.nextUpResult = JellyfinResult.Success(
+        ItemsResult(items = emptyList(), totalRecordCount = 0),
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<NextUpState.Empty>()
+    }
+  }
+
+  @Test
+  fun refresh_with_error_returns_error_state() {
+    runTest {
+      fakeLibraryService.nextUpResult = JellyfinResult.Error(
+        message = "Server error",
+        isEphemeral = true,
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<NextUpState.Error>()
+    }
+  }
+
+  @Test
+  fun items_without_id_are_filtered_out() {
+    runTest {
+      fakeLibraryService.nextUpResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(id = null, name = "No ID"),
+            BaseItemDto(id = "valid", name = "Valid Episode"),
+          ),
+          totalRecordCount = 2,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<NextUpState.Loaded>()
+      loaded.items.size shouldBe 1
+      loaded.items[0].id shouldBe "valid"
+    }
+  }
+}
+
+private class FakeNextUpLibraryService : JellyfinLibraryService {
+  var nextUpResult: JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  override suspend fun getResumeItems(
+    limit: Int?,
+    mediaTypes: List<String>?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  override suspend fun getNextUpEpisodes(
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = nextUpResult
+
+  override suspend fun getLatestItems(
+    parentId: String?,
+    includeItemTypes: List<String>?,
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<List<BaseItemDto>> = JellyfinResult.Success(emptyList())
+
+  override fun getImageUrl(
+    itemId: String,
+    imageType: ImageType,
+    maxWidth: Int?,
+    maxHeight: Int?,
+    tag: String?,
+    imageIndex: Int?,
+  ): String = "https://example.com/images/$itemId/${imageType.apiValue}"
+}

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/RecentlyAddedModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/RecentlyAddedModelTest.kt
@@ -1,0 +1,147 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.screens.home.RecentlyAddedState
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.sdk.core.model.ItemsResult
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class RecentlyAddedModelTest {
+  private lateinit var fakeLibraryService: FakeRecentLibraryService
+  private lateinit var model: RecentlyAddedModel
+
+  @BeforeTest
+  fun setUp() {
+    fakeLibraryService = FakeRecentLibraryService()
+    model = RecentlyAddedModel(libraryService = fakeLibraryService)
+  }
+
+  @Test
+  fun refresh_with_items_returns_loaded_state() {
+    runTest {
+      fakeLibraryService.latestItemsResult = JellyfinResult.Success(
+        listOf(
+          BaseItemDto(
+            id = "movie-1",
+            name = "Inception",
+            type = "Movie",
+            productionYear = 2010,
+          ),
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<RecentlyAddedState.Loaded>()
+      loaded.items.size shouldBe 1
+      loaded.items[0].id shouldBe "movie-1"
+      loaded.items[0].name shouldBe "Inception"
+      loaded.items[0].productionYear shouldBe 2010
+    }
+  }
+
+  @Test
+  fun refresh_with_empty_returns_empty_state() {
+    runTest {
+      fakeLibraryService.latestItemsResult = JellyfinResult.Success(emptyList())
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<RecentlyAddedState.Empty>()
+    }
+  }
+
+  @Test
+  fun refresh_with_error_returns_error_state() {
+    runTest {
+      fakeLibraryService.latestItemsResult = JellyfinResult.Error(
+        message = "Server error",
+        isEphemeral = true,
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<RecentlyAddedState.Error>()
+    }
+  }
+
+  @Test
+  fun items_without_id_are_filtered_out() {
+    runTest {
+      fakeLibraryService.latestItemsResult = JellyfinResult.Success(
+        listOf(
+          BaseItemDto(id = null, name = "No ID"),
+          BaseItemDto(id = "valid", name = "Valid Movie", type = "Movie"),
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<RecentlyAddedState.Loaded>()
+      loaded.items.size shouldBe 1
+      loaded.items[0].id shouldBe "valid"
+    }
+  }
+
+  @Test
+  fun episode_items_include_series_name() {
+    runTest {
+      fakeLibraryService.latestItemsResult = JellyfinResult.Success(
+        listOf(
+          BaseItemDto(
+            id = "ep-1",
+            name = "Pilot",
+            type = "Episode",
+            seriesName = "Lost",
+          ),
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<RecentlyAddedState.Loaded>()
+      loaded.items[0].seriesName shouldBe "Lost"
+    }
+  }
+}
+
+private class FakeRecentLibraryService : JellyfinLibraryService {
+  var latestItemsResult: JellyfinResult<List<BaseItemDto>> = JellyfinResult.Success(emptyList())
+
+  override suspend fun getResumeItems(
+    limit: Int?,
+    mediaTypes: List<String>?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  override suspend fun getNextUpEpisodes(
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  override suspend fun getLatestItems(
+    parentId: String?,
+    includeItemTypes: List<String>?,
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<List<BaseItemDto>> = latestItemsResult
+
+  override fun getImageUrl(
+    itemId: String,
+    imageType: ImageType,
+    maxWidth: Int?,
+    maxHeight: Int?,
+    tag: String?,
+    imageIndex: Int?,
+  ): String = "https://example.com/images/$itemId/${imageType.apiValue}"
+}

--- a/sdk/core/src/commonMain/kotlin/com/eygraber/jellyfin/sdk/core/api/library/LibraryApi.kt
+++ b/sdk/core/src/commonMain/kotlin/com/eygraber/jellyfin/sdk/core/api/library/LibraryApi.kt
@@ -133,6 +133,26 @@ class LibraryApi(
   )
 
   /**
+   * Gets the next episodes that the user should watch for their in-progress series.
+   *
+   * @param userId The user ID.
+   * @param limit Maximum number of items to return.
+   * @param fields Additional fields to include in the response.
+   */
+  suspend fun getNextUpEpisodes(
+    userId: String,
+    limit: Int? = null,
+    fields: List<String>? = null,
+  ): SdkResult<ItemsResult> = get(
+    path = "Shows/NextUp",
+    queryParams = mapOf(
+      "userId" to userId,
+      "limit" to limit,
+      "fields" to fields?.joinToString(","),
+    ),
+  )
+
+  /**
    * Generates the URL for an item image.
    *
    * @param itemId The item ID.

--- a/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinLibraryService.kt
+++ b/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinLibraryService.kt
@@ -95,6 +95,37 @@ class DefaultJellyfinLibraryService(
     }
   }
 
+  override suspend fun getNextUpEpisodes(
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> {
+    val serverInfo = sessionManager.currentServer.value
+      ?: return JellyfinResult.Error(
+        message = "Not connected to a server",
+        isEphemeral = false,
+      )
+
+    val userId = serverInfo.userId
+      ?: return JellyfinResult.Error(
+        message = "Not authenticated",
+        isEphemeral = false,
+      )
+
+    logger.debug(tag = TAG, message = "Fetching next up episodes for user: $userId")
+
+    val apiClient = sdk.createApiClient(serverInfo = serverInfo)
+    return try {
+      apiClient.libraryApi.getNextUpEpisodes(
+        userId = userId,
+        limit = limit,
+        fields = fields,
+      ).toJellyfinResult()
+    }
+    finally {
+      apiClient.close()
+    }
+  }
+
   override fun getImageUrl(
     itemId: String,
     imageType: ImageType,

--- a/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinLibraryService.kt
+++ b/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinLibraryService.kt
@@ -45,6 +45,18 @@ interface JellyfinLibraryService {
   ): JellyfinResult<List<BaseItemDto>>
 
   /**
+   * Gets the next episodes the user should watch for their in-progress series.
+   *
+   * @param limit Maximum number of items to return.
+   * @param fields Additional fields to include in the response.
+   * @return A [JellyfinResult] containing the [ItemsResult].
+   */
+  suspend fun getNextUpEpisodes(
+    limit: Int? = null,
+    fields: List<String>? = null,
+  ): JellyfinResult<ItemsResult>
+
+  /**
    * Generates the URL for an item image.
    *
    * @param itemId The item ID.


### PR DESCRIPTION
## Summary
- Add `NextUpModel` and `RecentlyAddedModel` ViceSources for fetching and displaying next up episodes and recently added items on the home screen
- Extend `JellyfinLibraryService` with `getNextUpEpisodes` backed by the `Shows/NextUp` SDK endpoint
- Add `NextUpRow` and `RecentlyAddedSection` UI components with placeholder image cards
- Wire both sections into the home compositor, view, and intent handling

## Test plan
- [x] `NextUpModelTest` covers loaded, empty, error, and null-id filtering scenarios (4 tests)
- [x] `RecentlyAddedModelTest` covers loaded, empty, error, null-id filtering, and series name scenarios (5 tests)
- [x] Updated `ContinueWatchingModelTest` fake to include `getNextUpEpisodes`
- [x] All checks pass (`./check`)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)