### PR TITLE
Add library cards for quick navigation to user libraries

### DIFF
--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
@@ -30,5 +30,8 @@ internal object JellyfinNavigators {
     onNavigateToItemDetail = { itemId ->
       backStack.add(JellyfinNavKeys.ComingSoon("Item Detail ($itemId)"))
     },
+    onNavigateToLibrary = { libraryId ->
+      backStack.add(JellyfinNavKeys.ComingSoon("Library ($libraryId)"))
+    },
   )
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.domain.session.SessionManager
 import com.eygraber.jellyfin.domain.session.SessionState
 import com.eygraber.jellyfin.screens.home.model.ContinueWatchingModel
+import com.eygraber.jellyfin.screens.home.model.LibrariesModel
 import com.eygraber.jellyfin.screens.home.model.NextUpModel
 import com.eygraber.jellyfin.screens.home.model.RecentlyAddedModel
 import com.eygraber.vice.ViceCompositor
@@ -19,6 +20,7 @@ class HomeCompositor(
   private val continueWatchingModel: ContinueWatchingModel,
   private val nextUpModel: NextUpModel,
   private val recentlyAddedModel: RecentlyAddedModel,
+  private val librariesModel: LibrariesModel,
 ) : ViceCompositor<HomeIntent, HomeViewState> {
   private var isLoading by mutableStateOf(true)
   private var isRefreshing by mutableStateOf(false)
@@ -38,6 +40,7 @@ class HomeCompositor(
     val continueWatchingState = continueWatchingModel.currentState()
     val nextUpState = nextUpModel.currentState()
     val recentlyAddedState = recentlyAddedModel.currentState()
+    val librariesState = librariesModel.currentState()
 
     return HomeViewState(
       userName = userName,
@@ -47,6 +50,7 @@ class HomeCompositor(
       continueWatchingState = continueWatchingState,
       nextUpState = nextUpState,
       recentlyAddedState = recentlyAddedState,
+      librariesState = librariesState,
     )
   }
 
@@ -57,6 +61,7 @@ class HomeCompositor(
       is HomeIntent.ContinueWatchingItemClicked -> navigator.navigateToItemDetail(intent.itemId)
       is HomeIntent.NextUpItemClicked -> navigator.navigateToItemDetail(intent.itemId)
       is HomeIntent.RecentlyAddedItemClicked -> navigator.navigateToItemDetail(intent.itemId)
+      is HomeIntent.LibraryClicked -> navigator.navigateToLibrary(intent.libraryId)
     }
   }
 
@@ -72,6 +77,7 @@ class HomeCompositor(
     continueWatchingModel.refresh()
     nextUpModel.refresh()
     recentlyAddedModel.refresh()
+    librariesModel.refresh()
 
     isRefreshing = false
   }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
@@ -6,4 +6,5 @@ sealed interface HomeIntent {
   data class ContinueWatchingItemClicked(val itemId: String) : HomeIntent
   data class NextUpItemClicked(val itemId: String) : HomeIntent
   data class RecentlyAddedItemClicked(val itemId: String) : HomeIntent
+  data class LibraryClicked(val libraryId: String) : HomeIntent
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeNavigator.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeNavigator.kt
@@ -3,6 +3,7 @@ package com.eygraber.jellyfin.screens.home
 class HomeNavigator(
   private val onNavigateBack: () -> Unit,
   private val onNavigateToItemDetail: (itemId: String) -> Unit,
+  private val onNavigateToLibrary: (libraryId: String) -> Unit,
 ) {
   fun navigateBack() {
     onNavigateBack()
@@ -10,5 +11,9 @@ class HomeNavigator(
 
   fun navigateToItemDetail(itemId: String) {
     onNavigateToItemDetail(itemId)
+  }
+
+  fun navigateToLibrary(libraryId: String) {
+    onNavigateToLibrary(libraryId)
   }
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.eygraber.jellyfin.screens.home.components.ContinueWatchingLoading
 import com.eygraber.jellyfin.screens.home.components.ContinueWatchingRow
+import com.eygraber.jellyfin.screens.home.components.LibraryCardsSection
 import com.eygraber.jellyfin.screens.home.components.NextUpRow
 import com.eygraber.jellyfin.screens.home.components.RecentlyAddedSection
 import com.eygraber.jellyfin.ui.compose.PreviewJellyfinScreen
@@ -132,6 +133,11 @@ private fun HomeContent(
       onItemClick = { itemId -> onIntent(HomeIntent.NextUpItemClicked(itemId)) },
     )
 
+    LibrariesHomeSection(
+      state = state.librariesState,
+      onLibraryClick = { libraryId -> onIntent(HomeIntent.LibraryClicked(libraryId)) },
+    )
+
     RecentlyAddedHomeSection(
       state = state.recentlyAddedState,
       onItemClick = { itemId -> onIntent(HomeIntent.RecentlyAddedItemClicked(itemId)) },
@@ -200,6 +206,28 @@ private fun RecentlyAddedHomeSection(
 
     is RecentlyAddedState.Empty,
     is RecentlyAddedState.Error,
+    -> Unit
+  }
+}
+
+@Composable
+private fun LibrariesHomeSection(
+  state: LibrariesState,
+  onLibraryClick: (libraryId: String) -> Unit,
+) {
+  when(state) {
+    is LibrariesState.Loading -> Unit
+
+    is LibrariesState.Loaded -> {
+      Spacer(modifier = Modifier.height(16.dp))
+      LibraryCardsSection(
+        libraries = state.libraries,
+        onLibraryClick = onLibraryClick,
+      )
+    }
+
+    is LibrariesState.Empty,
+    is LibrariesState.Error,
     -> Unit
   }
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
@@ -11,6 +11,7 @@ data class HomeViewState(
   val continueWatchingState: ContinueWatchingState = ContinueWatchingState.Loading,
   val nextUpState: NextUpState = NextUpState.Loading,
   val recentlyAddedState: RecentlyAddedState = RecentlyAddedState.Loading,
+  val librariesState: LibrariesState = LibrariesState.Loading,
 ) {
   companion object {
     val Loading = HomeViewState(isLoading = true)
@@ -119,3 +120,42 @@ data class RecentlyAddedItem(
   val imageUrl: String,
   val seriesName: String?,
 )
+
+@Immutable
+sealed interface LibrariesState {
+  data object Loading : LibrariesState
+  data object Empty : LibrariesState
+  data object Error : LibrariesState
+
+  data class Loaded(
+    val libraries: List<LibraryView>,
+  ) : LibrariesState
+}
+
+@Immutable
+data class LibraryView(
+  val id: String,
+  val name: String,
+  val collectionType: CollectionType,
+  val imageUrl: String?,
+)
+
+enum class CollectionType(val apiValue: String) {
+  Movies("movies"),
+  TvShows("tvshows"),
+  Music("music"),
+  MusicVideos("musicvideos"),
+  Collections("boxsets"),
+  Playlists("playlists"),
+  LiveTv("livetv"),
+  Photos("photos"),
+  HomeVideos("homevideos"),
+  Books("books"),
+  Unknown(""),
+  ;
+
+  companion object {
+    fun fromApiValue(value: String?): CollectionType =
+      entries.firstOrNull { it.apiValue.equals(other = value, ignoreCase = true) } ?: Unknown
+  }
+}

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/LibraryCardsSection.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/LibraryCardsSection.kt
@@ -1,0 +1,100 @@
+package com.eygraber.jellyfin.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.screens.home.LibraryView
+
+@Composable
+internal fun LibraryCardsSection(
+  libraries: List<LibraryView>,
+  onLibraryClick: (libraryId: String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier = modifier) {
+    Text(
+      text = "My Libraries",
+      style = MaterialTheme.typography.titleMedium,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    LazyRow(
+      contentPadding = PaddingValues(horizontal = 16.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      items(
+        items = libraries,
+        key = { it.id },
+      ) { library ->
+        LibraryCard(
+          library = library,
+          onClick = { onLibraryClick(library.id) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun LibraryCard(
+  library: LibraryView,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Card(
+    onClick = onClick,
+    modifier = modifier.width(libraryCardWidth),
+  ) {
+    Column {
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(libraryCardImageHeight)
+          .clip(MaterialTheme.shapes.medium)
+          .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = library.name.take(1).uppercase(),
+          style = MaterialTheme.typography.headlineLarge,
+          color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+      }
+
+      Text(
+        text = library.name,
+        style = MaterialTheme.typography.bodySmall,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(8.dp),
+      )
+    }
+  }
+}
+
+private val libraryCardWidth = 120.dp
+private val libraryCardImageHeight = 80.dp

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/LibrariesModel.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/model/LibrariesModel.kt
@@ -1,0 +1,78 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.eygraber.jellyfin.common.isSuccess
+import com.eygraber.jellyfin.screens.home.CollectionType
+import com.eygraber.jellyfin.screens.home.LibrariesState
+import com.eygraber.jellyfin.screens.home.LibraryView
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.vice.ViceSource
+import dev.zacsweers.metro.Inject
+
+@Inject
+class LibrariesModel(
+  private val libraryService: JellyfinLibraryService,
+) : ViceSource<LibrariesState> {
+  private var state by mutableStateOf<LibrariesState>(LibrariesState.Loading)
+
+  internal val stateForTest: LibrariesState get() = state
+
+  @Composable
+  override fun currentState(): LibrariesState {
+    LaunchedEffect(Unit) {
+      load()
+    }
+
+    return state
+  }
+
+  suspend fun refresh() {
+    load()
+  }
+
+  private suspend fun load() {
+    state = LibrariesState.Loading
+
+    val result = libraryService.getUserViews()
+
+    state = if(result.isSuccess()) {
+      val libraries = result.value.items
+        .filter { it.id != null }
+        .map { dto ->
+          val itemId = requireNotNull(dto.id)
+          LibraryView(
+            id = itemId,
+            name = dto.name.orEmpty(),
+            collectionType = CollectionType.fromApiValue(dto.collectionType),
+            imageUrl = dto.imageTags["Primary"]?.let { tag ->
+              libraryService.getImageUrl(
+                itemId = itemId,
+                imageType = ImageType.Primary,
+                maxWidth = IMAGE_MAX_WIDTH,
+                tag = tag,
+              )
+            },
+          )
+        }
+
+      if(libraries.isEmpty()) {
+        LibrariesState.Empty
+      }
+      else {
+        LibrariesState.Loaded(libraries = libraries)
+      }
+    }
+    else {
+      LibrariesState.Error
+    }
+  }
+
+  companion object {
+    private const val IMAGE_MAX_WIDTH = 300
+  }
+}

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/CollectionTypeTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/CollectionTypeTest.kt
@@ -1,0 +1,72 @@
+package com.eygraber.jellyfin.screens.home
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class CollectionTypeTest {
+  @Test
+  fun movies_maps_correctly() {
+    CollectionType.fromApiValue("movies") shouldBe CollectionType.Movies
+  }
+
+  @Test
+  fun tvshows_maps_correctly() {
+    CollectionType.fromApiValue("tvshows") shouldBe CollectionType.TvShows
+  }
+
+  @Test
+  fun music_maps_correctly() {
+    CollectionType.fromApiValue("music") shouldBe CollectionType.Music
+  }
+
+  @Test
+  fun musicvideos_maps_correctly() {
+    CollectionType.fromApiValue("musicvideos") shouldBe CollectionType.MusicVideos
+  }
+
+  @Test
+  fun boxsets_maps_correctly() {
+    CollectionType.fromApiValue("boxsets") shouldBe CollectionType.Collections
+  }
+
+  @Test
+  fun playlists_maps_correctly() {
+    CollectionType.fromApiValue("playlists") shouldBe CollectionType.Playlists
+  }
+
+  @Test
+  fun livetv_maps_correctly() {
+    CollectionType.fromApiValue("livetv") shouldBe CollectionType.LiveTv
+  }
+
+  @Test
+  fun photos_maps_correctly() {
+    CollectionType.fromApiValue("photos") shouldBe CollectionType.Photos
+  }
+
+  @Test
+  fun homevideos_maps_correctly() {
+    CollectionType.fromApiValue("homevideos") shouldBe CollectionType.HomeVideos
+  }
+
+  @Test
+  fun books_maps_correctly() {
+    CollectionType.fromApiValue("books") shouldBe CollectionType.Books
+  }
+
+  @Test
+  fun case_insensitive_mapping() {
+    CollectionType.fromApiValue("Movies") shouldBe CollectionType.Movies
+    CollectionType.fromApiValue("TVSHOWS") shouldBe CollectionType.TvShows
+  }
+
+  @Test
+  fun unknown_value_maps_to_unknown() {
+    CollectionType.fromApiValue("somethingCustom") shouldBe CollectionType.Unknown
+  }
+
+  @Test
+  fun null_value_maps_to_unknown() {
+    CollectionType.fromApiValue(null) shouldBe CollectionType.Unknown
+  }
+}

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/ContinueWatchingModelTest.kt
@@ -263,6 +263,10 @@ private class FakeJellyfinLibraryService : JellyfinLibraryService {
     fields: List<String>?,
   ): JellyfinResult<List<BaseItemDto>> = latestItemsResult
 
+  override suspend fun getUserViews(): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
   override fun getImageUrl(
     itemId: String,
     imageType: ImageType,

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/LibrariesModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/LibrariesModelTest.kt
@@ -1,0 +1,240 @@
+package com.eygraber.jellyfin.screens.home.model
+
+import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.screens.home.CollectionType
+import com.eygraber.jellyfin.screens.home.LibrariesState
+import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.sdk.core.model.ItemsResult
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class LibrariesModelTest {
+  private lateinit var fakeLibraryService: FakeLibrariesLibraryService
+  private lateinit var model: LibrariesModel
+
+  @BeforeTest
+  fun setUp() {
+    fakeLibraryService = FakeLibrariesLibraryService()
+    model = LibrariesModel(libraryService = fakeLibraryService)
+  }
+
+  @Test
+  fun refresh_with_libraries_returns_loaded_state() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(
+              id = "lib-1",
+              name = "Movies",
+              collectionType = "movies",
+              imageTags = mapOf("Primary" to "tag1"),
+            ),
+            BaseItemDto(
+              id = "lib-2",
+              name = "TV Shows",
+              collectionType = "tvshows",
+            ),
+          ),
+          totalRecordCount = 2,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<LibrariesState.Loaded>()
+      loaded.libraries.size shouldBe 2
+      loaded.libraries[0].id shouldBe "lib-1"
+      loaded.libraries[0].name shouldBe "Movies"
+      loaded.libraries[0].collectionType shouldBe CollectionType.Movies
+      loaded.libraries[1].id shouldBe "lib-2"
+      loaded.libraries[1].name shouldBe "TV Shows"
+      loaded.libraries[1].collectionType shouldBe CollectionType.TvShows
+    }
+  }
+
+  @Test
+  fun refresh_with_empty_returns_empty_state() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Success(
+        ItemsResult(items = emptyList(), totalRecordCount = 0),
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<LibrariesState.Empty>()
+    }
+  }
+
+  @Test
+  fun refresh_with_error_returns_error_state() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Error(
+        message = "Server error",
+        isEphemeral = true,
+      )
+
+      model.refresh()
+
+      model.stateForTest.shouldBeInstanceOf<LibrariesState.Error>()
+    }
+  }
+
+  @Test
+  fun items_without_id_are_filtered_out() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(id = null, name = "No ID Library"),
+            BaseItemDto(id = "valid", name = "Valid Library", collectionType = "movies"),
+          ),
+          totalRecordCount = 2,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<LibrariesState.Loaded>()
+      loaded.libraries.size shouldBe 1
+      loaded.libraries[0].id shouldBe "valid"
+    }
+  }
+
+  @Test
+  fun unknown_collection_type_maps_to_unknown() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(
+              id = "lib-1",
+              name = "Custom Library",
+              collectionType = "somethingCustom",
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<LibrariesState.Loaded>()
+      loaded.libraries[0].collectionType shouldBe CollectionType.Unknown
+    }
+  }
+
+  @Test
+  fun null_collection_type_maps_to_unknown() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(
+              id = "lib-1",
+              name = "Generic Library",
+              collectionType = null,
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<LibrariesState.Loaded>()
+      loaded.libraries[0].collectionType shouldBe CollectionType.Unknown
+    }
+  }
+
+  @Test
+  fun library_with_image_tag_has_image_url() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(
+              id = "lib-1",
+              name = "Movies",
+              collectionType = "movies",
+              imageTags = mapOf("Primary" to "abc123"),
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<LibrariesState.Loaded>()
+      loaded.libraries[0].imageUrl shouldBe "https://example.com/images/lib-1/Primary"
+    }
+  }
+
+  @Test
+  fun library_without_image_tag_has_null_image_url() {
+    runTest {
+      fakeLibraryService.userViewsResult = JellyfinResult.Success(
+        ItemsResult(
+          items = listOf(
+            BaseItemDto(
+              id = "lib-1",
+              name = "Movies",
+              collectionType = "movies",
+            ),
+          ),
+          totalRecordCount = 1,
+        ),
+      )
+
+      model.refresh()
+
+      val loaded = model.stateForTest.shouldBeInstanceOf<LibrariesState.Loaded>()
+      loaded.libraries[0].imageUrl shouldBe null
+    }
+  }
+}
+
+private class FakeLibrariesLibraryService : JellyfinLibraryService {
+  var userViewsResult: JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  override suspend fun getResumeItems(
+    limit: Int?,
+    mediaTypes: List<String>?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  override suspend fun getNextUpEpisodes(
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
+  override suspend fun getLatestItems(
+    parentId: String?,
+    includeItemTypes: List<String>?,
+    limit: Int?,
+    fields: List<String>?,
+  ): JellyfinResult<List<BaseItemDto>> = JellyfinResult.Success(emptyList())
+
+  override suspend fun getUserViews(): JellyfinResult<ItemsResult> = userViewsResult
+
+  override fun getImageUrl(
+    itemId: String,
+    imageType: ImageType,
+    maxWidth: Int?,
+    maxHeight: Int?,
+    tag: String?,
+    imageIndex: Int?,
+  ): String = "https://example.com/images/$itemId/${imageType.apiValue}"
+}

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/NextUpModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/NextUpModelTest.kt
@@ -125,6 +125,10 @@ private class FakeNextUpLibraryService : JellyfinLibraryService {
     fields: List<String>?,
   ): JellyfinResult<List<BaseItemDto>> = JellyfinResult.Success(emptyList())
 
+  override suspend fun getUserViews(): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
   override fun getImageUrl(
     itemId: String,
     imageType: ImageType,

--- a/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/RecentlyAddedModelTest.kt
+++ b/screens/home/src/commonTest/kotlin/com/eygraber/jellyfin/screens/home/model/RecentlyAddedModelTest.kt
@@ -136,6 +136,10 @@ private class FakeRecentLibraryService : JellyfinLibraryService {
     fields: List<String>?,
   ): JellyfinResult<List<BaseItemDto>> = latestItemsResult
 
+  override suspend fun getUserViews(): JellyfinResult<ItemsResult> = JellyfinResult.Success(
+    ItemsResult(items = emptyList(), totalRecordCount = 0),
+  )
+
   override fun getImageUrl(
     itemId: String,
     imageType: ImageType,

--- a/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinLibraryService.kt
+++ b/services/sdk/impl/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/impl/DefaultJellyfinLibraryService.kt
@@ -126,6 +126,32 @@ class DefaultJellyfinLibraryService(
     }
   }
 
+  override suspend fun getUserViews(): JellyfinResult<ItemsResult> {
+    val serverInfo = sessionManager.currentServer.value
+      ?: return JellyfinResult.Error(
+        message = "Not connected to a server",
+        isEphemeral = false,
+      )
+
+    val userId = serverInfo.userId
+      ?: return JellyfinResult.Error(
+        message = "Not authenticated",
+        isEphemeral = false,
+      )
+
+    logger.debug(tag = TAG, message = "Fetching user views for user: $userId")
+
+    val apiClient = sdk.createApiClient(serverInfo = serverInfo)
+    return try {
+      apiClient.libraryApi.getUserViews(
+        userId = userId,
+      ).toJellyfinResult()
+    }
+    finally {
+      apiClient.close()
+    }
+  }
+
   override fun getImageUrl(
     itemId: String,
     imageType: ImageType,

--- a/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinLibraryService.kt
+++ b/services/sdk/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/sdk/JellyfinLibraryService.kt
@@ -57,6 +57,13 @@ interface JellyfinLibraryService {
   ): JellyfinResult<ItemsResult>
 
   /**
+   * Gets the user's library views (e.g., Movies, TV Shows, Music).
+   *
+   * @return A [JellyfinResult] containing the [ItemsResult] of library views.
+   */
+  suspend fun getUserViews(): JellyfinResult<ItemsResult>
+
+  /**
    * Generates the URL for an item image.
    *
    * @param itemId The item ID.


### PR DESCRIPTION
## Summary
- Add `LibrariesModel` ViceSource that fetches user library views via `getUserViews` API endpoint
- Add `CollectionType` enum mapping Jellyfin collection types (movies, tvshows, music, etc.)
- Add `LibraryCardsSection` UI component with horizontally scrollable library cards
- Wire library navigation through to the home compositor and navigator

## Test plan
- [x] `LibrariesModelTest` covers loaded, empty, error, null-id filtering, unknown/null collection type, image URL presence/absence (8 tests)
- [x] `CollectionTypeTest` covers all known types, case insensitivity, unknown/null values (13 tests)
- [x] Updated all existing test fakes for new `getUserViews` service method
- [x] All checks pass (`./check`)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)