### PR TITLE
#47 Add filter, sort, and view toggle to libraries

### DIFF
--- a/screens/library-movies/build.gradle.kts
+++ b/screens/library-movies/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
 
       implementation(projects.ui.compose)
       implementation(projects.ui.icons)
+      implementation(projects.ui.libraryControls)
       implementation(projects.ui.material)
 
       implementation(libs.compose.foundation)

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryIntent.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryIntent.kt
@@ -1,9 +1,18 @@
 package com.eygraber.jellyfin.screens.library.movies
 
+import com.eygraber.jellyfin.data.items.ItemSortBy
+import com.eygraber.jellyfin.data.items.SortOrder
+import com.eygraber.jellyfin.ui.library.controls.LibraryFilters
+import com.eygraber.jellyfin.ui.library.controls.LibraryViewMode
+
 sealed interface MoviesLibraryIntent {
   data object LoadMore : MoviesLibraryIntent
   data object Refresh : MoviesLibraryIntent
   data object RetryLoad : MoviesLibraryIntent
   data class SelectMovie(val movieId: String) : MoviesLibraryIntent
+  data class ChangeSortOption(val sortBy: ItemSortBy, val sortOrder: SortOrder) : MoviesLibraryIntent
+  data class ChangeFilters(val filters: LibraryFilters) : MoviesLibraryIntent
+  data class ChangeViewMode(val viewMode: LibraryViewMode) : MoviesLibraryIntent
+  data object ToggleFilterSheet : MoviesLibraryIntent
   data object NavigateBack : MoviesLibraryIntent
 }

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryViewState.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryViewState.kt
@@ -1,6 +1,9 @@
 package com.eygraber.jellyfin.screens.library.movies
 
 import androidx.compose.runtime.Immutable
+import com.eygraber.jellyfin.ui.library.controls.LibraryFilters
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
+import com.eygraber.jellyfin.ui.library.controls.LibraryViewMode
 
 @Immutable
 data class MoviesLibraryViewState(
@@ -10,6 +13,12 @@ data class MoviesLibraryViewState(
   val error: MoviesLibraryError? = null,
   val hasMore: Boolean = false,
   val isEmpty: Boolean = false,
+  val sortConfig: LibrarySortConfig = LibrarySortConfig(),
+  val filters: LibraryFilters = LibraryFilters(),
+  val viewMode: LibraryViewMode = LibraryViewMode.Grid,
+  val availableGenres: List<String> = emptyList(),
+  val availableYears: List<Int> = emptyList(),
+  val isFilterSheetVisible: Boolean = false,
 ) {
   companion object {
     val Loading = MoviesLibraryViewState(isLoading = true)

--- a/screens/library-music/build.gradle.kts
+++ b/screens/library-music/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
 
       implementation(projects.ui.compose)
       implementation(projects.ui.icons)
+      implementation(projects.ui.libraryControls)
       implementation(projects.ui.material)
 
       implementation(libs.compose.foundation)

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import com.eygraber.jellyfin.screens.library.music.model.MusicLibraryModel
 import com.eygraber.jellyfin.screens.library.music.model.MusicLibraryModelError
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
 
@@ -34,6 +35,7 @@ class MusicLibraryCompositor(
         modelState.error == null &&
         modelState.artists.isEmpty() &&
         modelState.albums.isEmpty(),
+      sortConfig = modelState.sortConfig,
     )
   }
 
@@ -45,6 +47,14 @@ class MusicLibraryCompositor(
       is MusicLibraryIntent.SelectTab -> musicModel.switchTab(key.libraryId, intent.tab)
       is MusicLibraryIntent.SelectArtist -> navigator.navigateToArtistAlbums(intent.artistId)
       is MusicLibraryIntent.SelectAlbum -> navigator.navigateToAlbumTracks(intent.albumId)
+
+      is MusicLibraryIntent.ChangeSortOption -> {
+        musicModel.updateSortConfig(
+          LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder),
+        )
+        musicModel.loadInitial(key.libraryId)
+      }
+
       MusicLibraryIntent.NavigateBack -> navigator.navigateBack()
     }
   }

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryIntent.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryIntent.kt
@@ -1,5 +1,8 @@
 package com.eygraber.jellyfin.screens.library.music
 
+import com.eygraber.jellyfin.data.items.ItemSortBy
+import com.eygraber.jellyfin.data.items.SortOrder
+
 sealed interface MusicLibraryIntent {
   data object LoadMore : MusicLibraryIntent
   data object Refresh : MusicLibraryIntent
@@ -7,5 +10,6 @@ sealed interface MusicLibraryIntent {
   data class SelectTab(val tab: MusicTab) : MusicLibraryIntent
   data class SelectArtist(val artistId: String) : MusicLibraryIntent
   data class SelectAlbum(val albumId: String) : MusicLibraryIntent
+  data class ChangeSortOption(val sortBy: ItemSortBy, val sortOrder: SortOrder) : MusicLibraryIntent
   data object NavigateBack : MusicLibraryIntent
 }

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryView.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryView.kt
@@ -27,6 +27,8 @@ import com.eygraber.jellyfin.screens.library.music.components.ArtistsList
 import com.eygraber.jellyfin.ui.compose.PreviewJellyfinScreen
 import com.eygraber.jellyfin.ui.icons.ArrowBack
 import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+import com.eygraber.jellyfin.ui.library.controls.SortMenu
+import com.eygraber.jellyfin.ui.library.controls.musicSortOptions
 import com.eygraber.jellyfin.ui.material.theme.JellyfinPreviewTheme
 import com.eygraber.jellyfin.ui.material.theme.JellyfinTheme
 import com.eygraber.vice.ViceView
@@ -52,6 +54,15 @@ internal fun MusicLibraryView(
                   contentDescription = "Navigate back",
                 )
               }
+            },
+            actions = {
+              SortMenu(
+                sortConfig = state.sortConfig,
+                sortOptions = musicSortOptions,
+                onSortChange = { sortBy, sortOrder ->
+                  onIntent(MusicLibraryIntent.ChangeSortOption(sortBy = sortBy, sortOrder = sortOrder))
+                },
+              )
             },
           )
 

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryViewState.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryViewState.kt
@@ -1,6 +1,7 @@
 package com.eygraber.jellyfin.screens.library.music
 
 import androidx.compose.runtime.Immutable
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
 
 @Immutable
 data class MusicLibraryViewState(
@@ -12,6 +13,7 @@ data class MusicLibraryViewState(
   val error: MusicLibraryError? = null,
   val hasMore: Boolean = false,
   val isEmpty: Boolean = false,
+  val sortConfig: LibrarySortConfig = LibrarySortConfig(),
 ) {
   companion object {
     val Loading = MusicLibraryViewState(isLoading = true)

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/model/MusicLibraryModel.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/model/MusicLibraryModel.kt
@@ -5,15 +5,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.common.isSuccess
-import com.eygraber.jellyfin.data.items.ItemSortBy
 import com.eygraber.jellyfin.data.items.ItemsRepository
 import com.eygraber.jellyfin.data.items.LibraryItem
-import com.eygraber.jellyfin.data.items.SortOrder
 import com.eygraber.jellyfin.screens.library.music.AlbumItem
 import com.eygraber.jellyfin.screens.library.music.ArtistItem
 import com.eygraber.jellyfin.screens.library.music.MusicTab
 import com.eygraber.jellyfin.sdk.core.model.ImageType
 import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
 import com.eygraber.vice.ViceSource
 import dev.zacsweers.metro.Inject
 
@@ -25,6 +24,7 @@ data class MusicLibraryState(
   val isLoadingMore: Boolean = false,
   val hasMore: Boolean = false,
   val error: MusicLibraryModelError? = null,
+  val sortConfig: LibrarySortConfig = LibrarySortConfig(),
 )
 
 enum class MusicLibraryModelError {
@@ -81,12 +81,16 @@ class MusicLibraryModel(
     loadInitial(libraryId)
   }
 
+  fun updateSortConfig(sortConfig: LibrarySortConfig) {
+    state = state.copy(sortConfig = sortConfig)
+  }
+
   private suspend fun loadArtists(libraryId: String, isInitial: Boolean) {
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("MusicArtist"),
-      sortBy = ItemSortBy.SortName,
-      sortOrder = SortOrder.Ascending,
+      sortBy = state.sortConfig.sortBy,
+      sortOrder = state.sortConfig.sortOrder,
       startIndex = if(isInitial) 0 else currentStartIndex,
       limit = PAGE_SIZE,
     )
@@ -118,8 +122,8 @@ class MusicLibraryModel(
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("MusicAlbum"),
-      sortBy = ItemSortBy.SortName,
-      sortOrder = SortOrder.Ascending,
+      sortBy = state.sortConfig.sortBy,
+      sortOrder = state.sortConfig.sortOrder,
       startIndex = if(isInitial) 0 else currentStartIndex,
       limit = PAGE_SIZE,
     )

--- a/screens/library-tvshows/build.gradle.kts
+++ b/screens/library-tvshows/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
 
       implementation(projects.ui.compose)
       implementation(projects.ui.icons)
+      implementation(projects.ui.libraryControls)
       implementation(projects.ui.material)
 
       implementation(libs.compose.foundation)

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
@@ -2,8 +2,13 @@ package com.eygraber.jellyfin.screens.library.tvshows
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.screens.library.tvshows.model.TvShowsLibraryModel
 import com.eygraber.jellyfin.screens.library.tvshows.model.TvShowsLibraryModelError
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
+import com.eygraber.jellyfin.ui.library.controls.LibraryViewMode
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
 
@@ -13,6 +18,8 @@ class TvShowsLibraryCompositor(
   private val navigator: TvShowsLibraryNavigator,
   private val tvShowsModel: TvShowsLibraryModel,
 ) : ViceCompositor<TvShowsLibraryIntent, TvShowsLibraryViewState> {
+  private var isFilterSheetVisible by mutableStateOf(false)
+  private var viewMode by mutableStateOf(LibraryViewMode.Grid)
 
   @Composable
   override fun composite(): TvShowsLibraryViewState {
@@ -20,6 +27,7 @@ class TvShowsLibraryCompositor(
 
     LaunchedEffect(Unit) {
       tvShowsModel.loadInitial(key.libraryId)
+      tvShowsModel.loadAvailableFilters(key.libraryId)
     }
 
     return TvShowsLibraryViewState(
@@ -29,6 +37,12 @@ class TvShowsLibraryCompositor(
       error = modelState.error?.toViewError(),
       hasMore = modelState.hasMore,
       isEmpty = !modelState.isLoading && modelState.error == null && modelState.items.isEmpty(),
+      sortConfig = modelState.sortConfig,
+      filters = modelState.filters,
+      viewMode = viewMode,
+      availableGenres = modelState.availableGenres,
+      availableYears = modelState.availableYears,
+      isFilterSheetVisible = isFilterSheetVisible,
     )
   }
 
@@ -38,6 +52,25 @@ class TvShowsLibraryCompositor(
       TvShowsLibraryIntent.Refresh -> tvShowsModel.refresh(key.libraryId)
       TvShowsLibraryIntent.RetryLoad -> tvShowsModel.loadInitial(key.libraryId)
       is TvShowsLibraryIntent.SelectShow -> navigator.navigateToShowSeasons(intent.showId)
+
+      is TvShowsLibraryIntent.ChangeSortOption -> {
+        tvShowsModel.updateSortConfig(
+          LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder),
+        )
+        tvShowsModel.loadInitial(key.libraryId)
+      }
+
+      is TvShowsLibraryIntent.ChangeFilters -> {
+        tvShowsModel.updateFilters(intent.filters)
+        tvShowsModel.loadInitial(key.libraryId)
+      }
+
+      is TvShowsLibraryIntent.ChangeViewMode ->
+        viewMode = intent.viewMode
+
+      TvShowsLibraryIntent.ToggleFilterSheet ->
+        isFilterSheetVisible = !isFilterSheetVisible
+
       TvShowsLibraryIntent.NavigateBack -> navigator.navigateBack()
     }
   }

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryIntent.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryIntent.kt
@@ -1,9 +1,18 @@
 package com.eygraber.jellyfin.screens.library.tvshows
 
+import com.eygraber.jellyfin.data.items.ItemSortBy
+import com.eygraber.jellyfin.data.items.SortOrder
+import com.eygraber.jellyfin.ui.library.controls.LibraryFilters
+import com.eygraber.jellyfin.ui.library.controls.LibraryViewMode
+
 sealed interface TvShowsLibraryIntent {
   data object LoadMore : TvShowsLibraryIntent
   data object Refresh : TvShowsLibraryIntent
   data object RetryLoad : TvShowsLibraryIntent
   data class SelectShow(val showId: String) : TvShowsLibraryIntent
+  data class ChangeSortOption(val sortBy: ItemSortBy, val sortOrder: SortOrder) : TvShowsLibraryIntent
+  data class ChangeFilters(val filters: LibraryFilters) : TvShowsLibraryIntent
+  data class ChangeViewMode(val viewMode: LibraryViewMode) : TvShowsLibraryIntent
+  data object ToggleFilterSheet : TvShowsLibraryIntent
   data object NavigateBack : TvShowsLibraryIntent
 }

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryViewState.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryViewState.kt
@@ -1,6 +1,9 @@
 package com.eygraber.jellyfin.screens.library.tvshows
 
 import androidx.compose.runtime.Immutable
+import com.eygraber.jellyfin.ui.library.controls.LibraryFilters
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
+import com.eygraber.jellyfin.ui.library.controls.LibraryViewMode
 
 @Immutable
 data class TvShowsLibraryViewState(
@@ -10,6 +13,12 @@ data class TvShowsLibraryViewState(
   val error: TvShowsLibraryError? = null,
   val hasMore: Boolean = false,
   val isEmpty: Boolean = false,
+  val sortConfig: LibrarySortConfig = LibrarySortConfig(),
+  val filters: LibraryFilters = LibraryFilters(),
+  val viewMode: LibraryViewMode = LibraryViewMode.Grid,
+  val availableGenres: List<String> = emptyList(),
+  val availableYears: List<Int> = emptyList(),
+  val isFilterSheetVisible: Boolean = false,
 ) {
   companion object {
     val Loading = TvShowsLibraryViewState(isLoading = true)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -136,6 +136,7 @@ include(":services:splash-screen:public")
 include(":test-utils")
 include(":ui:compose")
 include(":ui:icons")
+include(":ui:library-controls")
 include(":ui:material")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/FilterList.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/FilterList.kt
@@ -1,0 +1,37 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.FilterList: ImageVector
+  get() {
+    if(internalFilterList != null) {
+      return requireNotNull(internalFilterList)
+    }
+    internalFilterList = materialIcon(name = "Filled.FilterList") {
+      materialPath {
+        moveTo(10.0f, 18.0f)
+        horizontalLineToRelative(4.0f)
+        verticalLineToRelative(-2.0f)
+        horizontalLineToRelative(-4.0f)
+        verticalLineToRelative(2.0f)
+        close()
+        moveTo(3.0f, 6.0f)
+        verticalLineToRelative(2.0f)
+        horizontalLineToRelative(18.0f)
+        lineTo(21.0f, 6.0f)
+        lineTo(3.0f, 6.0f)
+        close()
+        moveTo(6.0f, 13.0f)
+        horizontalLineToRelative(12.0f)
+        verticalLineToRelative(-2.0f)
+        lineTo(6.0f, 11.0f)
+        verticalLineToRelative(2.0f)
+        close()
+      }
+    }
+    return requireNotNull(internalFilterList)
+  }
+
+private var internalFilterList: ImageVector? = null

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/GridView.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/GridView.kt
@@ -1,0 +1,43 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.GridView: ImageVector
+  get() {
+    if(internalGridView != null) {
+      return requireNotNull(internalGridView)
+    }
+    internalGridView = materialIcon(name = "Filled.GridView") {
+      materialPath {
+        moveTo(3.0f, 3.0f)
+        verticalLineToRelative(8.0f)
+        horizontalLineToRelative(8.0f)
+        lineTo(11.0f, 3.0f)
+        lineTo(3.0f, 3.0f)
+        close()
+        moveTo(13.0f, 3.0f)
+        verticalLineToRelative(8.0f)
+        horizontalLineToRelative(8.0f)
+        lineTo(21.0f, 3.0f)
+        horizontalLineToRelative(-8.0f)
+        close()
+        moveTo(3.0f, 13.0f)
+        verticalLineToRelative(8.0f)
+        horizontalLineToRelative(8.0f)
+        verticalLineToRelative(-8.0f)
+        lineTo(3.0f, 13.0f)
+        close()
+        moveTo(13.0f, 13.0f)
+        verticalLineToRelative(8.0f)
+        horizontalLineToRelative(8.0f)
+        verticalLineToRelative(-8.0f)
+        horizontalLineToRelative(-8.0f)
+        close()
+      }
+    }
+    return requireNotNull(internalGridView)
+  }
+
+private var internalGridView: ImageVector? = null

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Sort.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Sort.kt
@@ -1,0 +1,37 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.Sort: ImageVector
+  get() {
+    if(internalSort != null) {
+      return requireNotNull(internalSort)
+    }
+    internalSort = materialIcon(name = "AutoMirrored.Filled.Sort") {
+      materialPath {
+        moveTo(3.0f, 18.0f)
+        horizontalLineToRelative(6.0f)
+        verticalLineToRelative(-2.0f)
+        lineTo(3.0f, 16.0f)
+        verticalLineToRelative(2.0f)
+        close()
+        moveTo(3.0f, 6.0f)
+        verticalLineToRelative(2.0f)
+        horizontalLineToRelative(18.0f)
+        lineTo(21.0f, 6.0f)
+        lineTo(3.0f, 6.0f)
+        close()
+        moveTo(3.0f, 13.0f)
+        horizontalLineToRelative(12.0f)
+        verticalLineToRelative(-2.0f)
+        lineTo(3.0f, 11.0f)
+        verticalLineToRelative(2.0f)
+        close()
+      }
+    }
+    return requireNotNull(internalSort)
+  }
+
+private var internalSort: ImageVector? = null

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/ViewList.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/ViewList.kt
@@ -1,0 +1,55 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.ViewList: ImageVector
+  get() {
+    if(internalViewList != null) {
+      return requireNotNull(internalViewList)
+    }
+    internalViewList = materialIcon(name = "Filled.ViewList") {
+      materialPath {
+        moveTo(4.0f, 14.0f)
+        horizontalLineToRelative(4.0f)
+        verticalLineToRelative(-4.0f)
+        lineTo(4.0f, 10.0f)
+        verticalLineToRelative(4.0f)
+        close()
+        moveTo(4.0f, 19.0f)
+        horizontalLineToRelative(4.0f)
+        verticalLineToRelative(-4.0f)
+        lineTo(4.0f, 15.0f)
+        verticalLineToRelative(4.0f)
+        close()
+        moveTo(4.0f, 9.0f)
+        horizontalLineToRelative(4.0f)
+        lineTo(8.0f, 5.0f)
+        lineTo(4.0f, 5.0f)
+        verticalLineToRelative(4.0f)
+        close()
+        moveTo(9.0f, 14.0f)
+        horizontalLineToRelative(12.0f)
+        verticalLineToRelative(-4.0f)
+        lineTo(9.0f, 10.0f)
+        verticalLineToRelative(4.0f)
+        close()
+        moveTo(9.0f, 19.0f)
+        horizontalLineToRelative(12.0f)
+        verticalLineToRelative(-4.0f)
+        lineTo(9.0f, 15.0f)
+        verticalLineToRelative(4.0f)
+        close()
+        moveTo(9.0f, 5.0f)
+        verticalLineToRelative(4.0f)
+        horizontalLineToRelative(12.0f)
+        lineTo(21.0f, 5.0f)
+        lineTo(9.0f, 5.0f)
+        close()
+      }
+    }
+    return requireNotNull(internalViewList)
+  }
+
+private var internalViewList: ImageVector? = null

--- a/ui/library-controls/build.gradle.kts
+++ b/ui/library-controls/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+  alias(libs.plugins.conventionsAndroidKmpLibrary)
+  alias(libs.plugins.conventionsComposeMultiplatform)
+  alias(libs.plugins.conventionsDetekt)
+  alias(libs.plugins.conventionsKotlinMultiplatform)
+  alias(libs.plugins.conventionsProjectCommon)
+  alias(libs.plugins.dependencyAnalysis)
+}
+
+kotlin {
+  defaultKmpTargets(
+    project = project,
+    androidNamespace = "com.eygraber.jellyfin.ui.library.controls",
+  )
+
+  sourceSets {
+    commonMain.dependencies {
+      implementation(projects.data.items.public)
+
+      implementation(projects.ui.icons)
+
+      implementation(libs.compose.foundation)
+      implementation(libs.compose.foundationLayout)
+      implementation(libs.compose.material3)
+      api(libs.compose.runtime)
+      implementation(libs.compose.runtimeAnnotation)
+      implementation(libs.compose.ui)
+    }
+  }
+}

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/ActiveFilterChips.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/ActiveFilterChips.kt
@@ -1,0 +1,67 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.ui.icons.Close
+import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+
+/**
+ * Horizontal scrollable row showing active filter chips with dismiss action.
+ */
+@Composable
+fun ActiveFilterChips(
+  filters: LibraryFilters,
+  onRemoveGenre: (String) -> Unit,
+  onRemoveYear: (Int) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  if(!filters.hasActiveFilters) return
+
+  LazyRow(
+    modifier = modifier,
+    contentPadding = PaddingValues(horizontal = 16.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    items(
+      items = filters.genres,
+      key = { "genre-$it" },
+    ) { genre ->
+      FilterChip(
+        selected = true,
+        onClick = { onRemoveGenre(genre) },
+        label = { Text(genre) },
+        trailingIcon = {
+          Icon(
+            imageVector = JellyfinIcons.Close,
+            contentDescription = "Remove $genre filter",
+          )
+        },
+      )
+    }
+
+    items(
+      items = filters.years,
+      key = { "year-$it" },
+    ) { year ->
+      FilterChip(
+        selected = true,
+        onClick = { onRemoveYear(year) },
+        label = { Text(year.toString()) },
+        trailingIcon = {
+          Icon(
+            imageVector = JellyfinIcons.Close,
+            contentDescription = "Remove $year filter",
+          )
+        },
+      )
+    }
+  }
+}

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/FilterButton.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/FilterButton.kt
@@ -1,0 +1,45 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.ui.icons.FilterList
+import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+
+/**
+ * Filter icon button with badge showing active filter count.
+ */
+@Composable
+fun FilterButton(
+  activeFilterCount: Int,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Box(modifier = modifier) {
+    IconButton(onClick = onClick) {
+      Icon(
+        imageVector = JellyfinIcons.FilterList,
+        contentDescription = "Filter",
+      )
+    }
+
+    if(activeFilterCount > 0) {
+      Badge(
+        modifier = Modifier
+          .align(Alignment.TopEnd)
+          .offset(x = (-4).dp, y = 4.dp)
+          .size(16.dp),
+      ) {
+        Text(activeFilterCount.toString())
+      }
+    }
+  }
+}

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/FilterSheet.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/FilterSheet.kt
@@ -1,0 +1,132 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Bottom sheet for selecting genre and year filters.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun FilterSheet(
+  filters: LibraryFilters,
+  availableGenres: List<String>,
+  availableYears: List<Int>,
+  onFilterChange: (LibraryFilters) -> Unit,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+  ModalBottomSheet(
+    onDismissRequest = onDismiss,
+    sheetState = sheetState,
+    modifier = modifier,
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp)
+        .padding(bottom = 32.dp),
+    ) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+          text = "Filters",
+          style = MaterialTheme.typography.titleLarge,
+        )
+
+        if(filters.hasActiveFilters) {
+          TextButton(onClick = { onFilterChange(LibraryFilters()) }) {
+            Text("Clear All")
+          }
+        }
+      }
+
+      Spacer(modifier = Modifier.height(16.dp))
+
+      if(availableGenres.isNotEmpty()) {
+        Text(
+          text = "Genres",
+          style = MaterialTheme.typography.titleMedium,
+          modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        FlowRow(
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          availableGenres.forEach { genre ->
+            val isSelected = genre in filters.genres
+            FilterChip(
+              selected = isSelected,
+              onClick = {
+                val newGenres = if(isSelected) {
+                  filters.genres - genre
+                }
+                else {
+                  filters.genres + genre
+                }
+                onFilterChange(filters.copy(genres = newGenres))
+              },
+              label = { Text(genre) },
+            )
+          }
+        }
+      }
+
+      if(availableYears.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+          text = "Year",
+          style = MaterialTheme.typography.titleMedium,
+          modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        FlowRow(
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          availableYears.forEach { year ->
+            val isSelected = year in filters.years
+            FilterChip(
+              selected = isSelected,
+              onClick = {
+                val newYears = if(isSelected) {
+                  filters.years - year
+                }
+                else {
+                  filters.years + year
+                }
+                onFilterChange(filters.copy(years = newYears))
+              },
+              label = { Text(year.toString()) },
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/LibraryFilter.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/LibraryFilter.kt
@@ -1,0 +1,18 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Represents the active filters applied to a library view.
+ */
+@Immutable
+data class LibraryFilters(
+  val genres: List<String> = emptyList(),
+  val years: List<Int> = emptyList(),
+) {
+  val hasActiveFilters: Boolean
+    get() = genres.isNotEmpty() || years.isNotEmpty()
+
+  val activeFilterCount: Int
+    get() = genres.size + years.size
+}

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/LibrarySortOption.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/LibrarySortOption.kt
@@ -1,0 +1,53 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.runtime.Immutable
+import com.eygraber.jellyfin.data.items.ItemSortBy
+import com.eygraber.jellyfin.data.items.SortOrder
+
+/**
+ * Represents a sort option for library browsing screens.
+ */
+@Immutable
+data class LibrarySortOption(
+  val sortBy: ItemSortBy,
+  val label: String,
+)
+
+/**
+ * Combined sort configuration with sort field and direction.
+ */
+@Immutable
+data class LibrarySortConfig(
+  val sortBy: ItemSortBy = ItemSortBy.SortName,
+  val sortOrder: SortOrder = SortOrder.Ascending,
+)
+
+/**
+ * Standard sort options for movie libraries.
+ */
+val movieSortOptions = listOf(
+  LibrarySortOption(sortBy = ItemSortBy.SortName, label = "Title"),
+  LibrarySortOption(sortBy = ItemSortBy.DateCreated, label = "Date Added"),
+  LibrarySortOption(sortBy = ItemSortBy.PremiereDate, label = "Release Date"),
+  LibrarySortOption(sortBy = ItemSortBy.CommunityRating, label = "Rating"),
+  LibrarySortOption(sortBy = ItemSortBy.Runtime, label = "Runtime"),
+)
+
+/**
+ * Standard sort options for TV show libraries.
+ */
+val tvShowSortOptions = listOf(
+  LibrarySortOption(sortBy = ItemSortBy.SortName, label = "Title"),
+  LibrarySortOption(sortBy = ItemSortBy.DateCreated, label = "Date Added"),
+  LibrarySortOption(sortBy = ItemSortBy.PremiereDate, label = "Release Date"),
+  LibrarySortOption(sortBy = ItemSortBy.CommunityRating, label = "Rating"),
+)
+
+/**
+ * Standard sort options for music libraries.
+ */
+val musicSortOptions = listOf(
+  LibrarySortOption(sortBy = ItemSortBy.SortName, label = "Title"),
+  LibrarySortOption(sortBy = ItemSortBy.DateCreated, label = "Date Added"),
+  LibrarySortOption(sortBy = ItemSortBy.ProductionYear, label = "Year"),
+)

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/SortMenu.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/SortMenu.kt
@@ -1,0 +1,99 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.data.items.ItemSortBy
+import com.eygraber.jellyfin.data.items.SortOrder
+import com.eygraber.jellyfin.ui.icons.Check
+import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+import com.eygraber.jellyfin.ui.icons.Sort
+
+/**
+ * Dropdown menu for selecting sort field and order.
+ */
+@Composable
+fun SortMenu(
+  sortConfig: LibrarySortConfig,
+  sortOptions: List<LibrarySortOption>,
+  onSortChange: (sortBy: ItemSortBy, sortOrder: SortOrder) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var isExpanded by remember { mutableStateOf(false) }
+
+  IconButton(
+    onClick = { isExpanded = true },
+    modifier = modifier,
+  ) {
+    Icon(
+      imageVector = JellyfinIcons.Sort,
+      contentDescription = "Sort",
+    )
+  }
+
+  DropdownMenu(
+    expanded = isExpanded,
+    onDismissRequest = { isExpanded = false },
+  ) {
+    sortOptions.forEach { option ->
+      val isSelected = sortConfig.sortBy == option.sortBy
+
+      DropdownMenuItem(
+        text = {
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(text = option.label)
+
+            if(isSelected) {
+              Spacer(modifier = Modifier.width(8.dp))
+
+              Text(
+                text = if(sortConfig.sortOrder == SortOrder.Ascending) "\u2191" else "\u2193",
+                style = MaterialTheme.typography.bodyMedium,
+              )
+            }
+          }
+        },
+        onClick = {
+          val newOrder = if(isSelected) {
+            sortConfig.sortOrder.toggle()
+          }
+          else {
+            SortOrder.Ascending
+          }
+          onSortChange(option.sortBy, newOrder)
+          isExpanded = false
+        },
+        leadingIcon = if(isSelected) {
+          {
+            Icon(
+              imageVector = JellyfinIcons.Check,
+              contentDescription = null,
+            )
+          }
+        }
+        else {
+          null
+        },
+      )
+    }
+  }
+}
+
+private fun SortOrder.toggle(): SortOrder = when(this) {
+  SortOrder.Ascending -> SortOrder.Descending
+  SortOrder.Descending -> SortOrder.Ascending
+}

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/ViewToggle.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/ViewToggle.kt
@@ -1,0 +1,49 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.eygraber.jellyfin.ui.icons.GridView
+import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+import com.eygraber.jellyfin.ui.icons.ViewList
+
+/**
+ * View modes for library content display.
+ */
+enum class LibraryViewMode {
+  Grid,
+  List,
+}
+
+/**
+ * Toggle button for switching between grid and list view modes.
+ */
+@Composable
+fun ViewToggle(
+  viewMode: LibraryViewMode,
+  onViewModeChange: (LibraryViewMode) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  IconButton(
+    onClick = {
+      val newMode = when(viewMode) {
+        LibraryViewMode.Grid -> LibraryViewMode.List
+        LibraryViewMode.List -> LibraryViewMode.Grid
+      }
+      onViewModeChange(newMode)
+    },
+    modifier = modifier,
+  ) {
+    Icon(
+      imageVector = when(viewMode) {
+        LibraryViewMode.Grid -> JellyfinIcons.ViewList
+        LibraryViewMode.List -> JellyfinIcons.GridView
+      },
+      contentDescription = when(viewMode) {
+        LibraryViewMode.Grid -> "Switch to list view"
+        LibraryViewMode.List -> "Switch to grid view"
+      },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Creates new `ui/library-controls` module with reusable SortMenu, FilterSheet, FilterButton, ActiveFilterChips, and ViewToggle components
- Adds Sort, FilterList, GridView, and ViewList icons to the icon module
- Integrates sort/filter controls into Movies library (sort, genre filter, view toggle)
- Integrates sort/filter controls into TV Shows library (sort, genre filter, view toggle)
- Integrates sort controls into Music library (sort menu)
- Models now use sort configuration and filters in API requests for server-side processing
- Adds tests for sort config, filter updates, and available genre loading

## Test plan
- [x] All existing tests pass (`./check` passes)
- [x] Unit tests for `updateSortConfig`, `updateFilters`, `loadAvailableFilters` in MoviesLibraryModel
- [ ] Verify sort menu opens and shows sort options with check mark on active option
- [ ] Verify changing sort triggers data reload with new sort parameters
- [ ] Verify filter sheet opens showing available genres
- [ ] Verify selecting/deselecting genre filters refreshes content
- [ ] Verify active filter chips appear below toolbar and can be dismissed
- [ ] Verify view toggle icon switches between grid and list icons
- [ ] Verify filter badge shows active filter count

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)