### PR TITLE
#51 Enhance album and artist detail screens

### DIFF
--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
@@ -164,6 +164,9 @@ internal object JellyfinNavigators {
     onNavigateToTrackPlayback = { trackId ->
       backStack.add(JellyfinNavKeys.ComingSoon("Track Playback ($trackId)"))
     },
+    onNavigateToArtist = { artistId ->
+      backStack.add(ArtistAlbumsKey(artistId = artistId))
+    },
   )
 
   fun collectionsLibrary(

--- a/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksCompositor.kt
+++ b/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksCompositor.kt
@@ -23,8 +23,7 @@ class AlbumTracksCompositor(
     }
 
     return AlbumTracksViewState(
-      albumName = modelState.albumName,
-      artistName = modelState.artistName,
+      album = modelState.album,
       tracks = modelState.tracks,
       isLoading = modelState.isLoading,
       error = modelState.error?.toViewError(),
@@ -36,7 +35,17 @@ class AlbumTracksCompositor(
     when(intent) {
       AlbumTracksIntent.RetryLoad -> tracksModel.loadTracks(key.albumId)
       is AlbumTracksIntent.SelectTrack -> navigator.navigateToTrackPlayback(intent.trackId)
+      AlbumTracksIntent.PlayAll -> Unit // Playback not yet implemented
+      AlbumTracksIntent.ShufflePlay -> Unit // Playback not yet implemented
+      AlbumTracksIntent.ToggleFavorite -> Unit // Favorites not yet implemented
+      AlbumTracksIntent.NavigateToArtist -> navigateToArtist()
       AlbumTracksIntent.NavigateBack -> navigator.navigateBack()
+    }
+  }
+
+  private fun navigateToArtist() {
+    tracksModel.currentAlbumArtistId()?.let { artistId ->
+      navigator.navigateToArtist(artistId)
     }
   }
 

--- a/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksIntent.kt
+++ b/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksIntent.kt
@@ -3,5 +3,9 @@ package com.eygraber.jellyfin.screens.music.album.tracks
 sealed interface AlbumTracksIntent {
   data object RetryLoad : AlbumTracksIntent
   data class SelectTrack(val trackId: String) : AlbumTracksIntent
+  data object PlayAll : AlbumTracksIntent
+  data object ShufflePlay : AlbumTracksIntent
+  data object ToggleFavorite : AlbumTracksIntent
+  data object NavigateToArtist : AlbumTracksIntent
   data object NavigateBack : AlbumTracksIntent
 }

--- a/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksNavigator.kt
+++ b/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksNavigator.kt
@@ -3,6 +3,7 @@ package com.eygraber.jellyfin.screens.music.album.tracks
 class AlbumTracksNavigator(
   private val onNavigateBack: () -> Unit,
   private val onNavigateToTrackPlayback: (trackId: String) -> Unit,
+  private val onNavigateToArtist: (artistId: String) -> Unit,
 ) {
   fun navigateBack() {
     onNavigateBack()
@@ -10,5 +11,9 @@ class AlbumTracksNavigator(
 
   fun navigateToTrackPlayback(trackId: String) {
     onNavigateToTrackPlayback(trackId)
+  }
+
+  fun navigateToArtist(artistId: String) {
+    onNavigateToArtist(artistId)
   }
 }

--- a/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksViewState.kt
+++ b/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/AlbumTracksViewState.kt
@@ -4,8 +4,7 @@ import androidx.compose.runtime.Immutable
 
 @Immutable
 data class AlbumTracksViewState(
-  val albumName: String = "",
-  val artistName: String = "",
+  val album: AlbumDetail? = null,
   val tracks: List<TrackItem> = emptyList(),
   val isLoading: Boolean = true,
   val error: AlbumTracksError? = null,
@@ -24,6 +23,17 @@ sealed interface AlbumTracksError {
     override val message: String = "Unable to connect to server",
   ) : AlbumTracksError
 }
+
+@Immutable
+data class AlbumDetail(
+  val id: String,
+  val name: String,
+  val artistName: String,
+  val artistId: String?,
+  val productionYear: Int?,
+  val genre: String?,
+  val albumArtUrl: String?,
+)
 
 @Immutable
 data class TrackItem(

--- a/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/components/TracksList.kt
+++ b/screens/music-album-tracks/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/components/TracksList.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,18 +22,37 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.eygraber.jellyfin.screens.music.album.tracks.AlbumDetail
+import com.eygraber.jellyfin.screens.music.album.tracks.AlbumHeader
 import com.eygraber.jellyfin.screens.music.album.tracks.TrackItem
+import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+import com.eygraber.jellyfin.ui.icons.PlayArrow
+
+private const val PLAY_ICON_SIZE = 20
 
 @Composable
 internal fun TracksList(
+  album: AlbumDetail?,
   tracks: List<TrackItem>,
   onTrackClick: (trackId: String) -> Unit,
+  onPlayAll: () -> Unit,
+  onShuffle: () -> Unit,
+  onArtistClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   LazyColumn(
     contentPadding = PaddingValues(vertical = 8.dp),
     modifier = modifier.fillMaxSize(),
   ) {
+    item(key = "album-header") {
+      AlbumHeader(
+        album = album,
+        onPlayAll = onPlayAll,
+        onShuffle = onShuffle,
+        onArtistClick = onArtistClick,
+      )
+    }
+
     items(
       items = tracks,
       key = { it.id },
@@ -86,6 +108,18 @@ private fun TrackRow(
         text = duration,
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+
+    IconButton(
+      onClick = onClick,
+      modifier = Modifier.size(32.dp),
+    ) {
+      Icon(
+        imageVector = JellyfinIcons.PlayArrow,
+        contentDescription = "Play track",
+        modifier = Modifier.size(PLAY_ICON_SIZE.dp),
+        tint = MaterialTheme.colorScheme.primary,
       )
     }
   }

--- a/screens/music-album-tracks/src/commonTest/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/model/AlbumTracksModelTest.kt
+++ b/screens/music-album-tracks/src/commonTest/kotlin/com/eygraber/jellyfin/screens/music/album/tracks/model/AlbumTracksModelTest.kt
@@ -6,6 +6,8 @@ import com.eygraber.jellyfin.data.items.ItemsRepository
 import com.eygraber.jellyfin.data.items.LibraryItem
 import com.eygraber.jellyfin.data.items.PaginatedResult
 import com.eygraber.jellyfin.data.items.SortOrder
+import com.eygraber.jellyfin.sdk.core.model.ImageType
+import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -16,21 +18,32 @@ import kotlin.test.Test
 
 class AlbumTracksModelTest {
   private lateinit var fakeRepository: FakeItemsRepository
+  private lateinit var fakeLibraryService: FakeAlbumTracksLibraryService
   private lateinit var model: AlbumTracksModel
 
   @BeforeTest
   fun setUp() {
     fakeRepository = FakeItemsRepository()
+    fakeLibraryService = FakeAlbumTracksLibraryService()
     model = AlbumTracksModel(
       itemsRepository = fakeRepository,
+      libraryService = fakeLibraryService,
     )
   }
 
   @Test
-  fun loadTracks_success_populates_tracks() {
+  fun loadTracks_success_populates_album_detail_and_tracks() {
     runTest {
       fakeRepository.getItemResult = JellyfinResult.Success(
-        createLibraryItem(id = "album-1", name = "The Dark Side of the Moon", seriesName = "Pink Floyd"),
+        createLibraryItem(
+          id = "album-1",
+          name = "The Dark Side of the Moon",
+          seriesName = "Pink Floyd",
+          seriesId = "artist-1",
+          primaryImageTag = "tag1",
+          officialRating = "Progressive Rock",
+          productionYear = 1973,
+        ),
       )
 
       fakeRepository.getItemsResult = JellyfinResult.Success(
@@ -61,8 +74,16 @@ class AlbumTracksModelTest {
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
       state.error.shouldBeNull()
-      state.albumName shouldBe "The Dark Side of the Moon"
-      state.artistName shouldBe "Pink Floyd"
+
+      val album = state.album
+      album.shouldNotBeNull()
+      album.name shouldBe "The Dark Side of the Moon"
+      album.artistName shouldBe "Pink Floyd"
+      album.artistId shouldBe "artist-1"
+      album.productionYear shouldBe 1973
+      album.genre shouldBe "Progressive Rock"
+      album.albumArtUrl.shouldNotBeNull()
+
       state.tracks.size shouldBe 2
       state.tracks[0].name shouldBe "Speak to Me"
       state.tracks[0].trackNumber shouldBe 1
@@ -122,6 +143,43 @@ class AlbumTracksModelTest {
   }
 
   @Test
+  fun album_without_image_tag_has_null_art_url() {
+    runTest {
+      fakeRepository.getItemResult = JellyfinResult.Success(
+        createLibraryItem(id = "album-1", name = "Album", primaryImageTag = null),
+      )
+
+      fakeRepository.getItemsResult = JellyfinResult.Success(
+        PaginatedResult(items = emptyList(), totalRecordCount = 0, startIndex = 0),
+      )
+
+      model.loadTracks("album-1")
+
+      val state = model.stateForTest
+      val album = state.album
+      album.shouldNotBeNull()
+      album.albumArtUrl.shouldBeNull()
+    }
+  }
+
+  @Test
+  fun currentAlbumArtistId_returns_artist_id_after_load() {
+    runTest {
+      fakeRepository.getItemResult = JellyfinResult.Success(
+        createLibraryItem(id = "album-1", name = "Album", seriesId = "artist-42"),
+      )
+
+      fakeRepository.getItemsResult = JellyfinResult.Success(
+        PaginatedResult(items = emptyList(), totalRecordCount = 0, startIndex = 0),
+      )
+
+      model.loadTracks("album-1")
+
+      model.currentAlbumArtistId() shouldBe "artist-42"
+    }
+  }
+
+  @Test
   fun formatDuration_formats_correctly() {
     AlbumTracksModel.formatDuration(0L) shouldBe "0:00"
     AlbumTracksModel.formatDuration(10_000_000L) shouldBe "0:01"
@@ -130,6 +188,7 @@ class AlbumTracksModelTest {
     AlbumTracksModel.formatDuration(3_600_000_000L) shouldBe "6:00"
   }
 
+  @Suppress("LongParameterList")
   private fun createLibraryItem(
     id: String,
     name: String,
@@ -137,6 +196,9 @@ class AlbumTracksModelTest {
     productionYear: Int? = null,
     runTimeTicks: Long? = null,
     seriesName: String? = null,
+    seriesId: String? = null,
+    primaryImageTag: String? = null,
+    officialRating: String? = null,
   ) = LibraryItem(
     id = id,
     name = name,
@@ -145,11 +207,11 @@ class AlbumTracksModelTest {
     overview = null,
     productionYear = productionYear,
     communityRating = null,
-    officialRating = null,
-    primaryImageTag = null,
+    officialRating = officialRating,
+    primaryImageTag = primaryImageTag,
     backdropImageTags = emptyList(),
     seriesName = seriesName,
-    seriesId = null,
+    seriesId = seriesId,
     childCount = null,
     runTimeTicks = runTimeTicks,
   )
@@ -187,4 +249,57 @@ private class FakeItemsRepository : ItemsRepository {
     itemId: String,
     limit: Int?,
   ): JellyfinResult<List<LibraryItem>> = getSimilarItemsResult
+}
+
+private class FakeAlbumTracksLibraryService : JellyfinLibraryService {
+  override fun getImageUrl(
+    itemId: String,
+    imageType: ImageType,
+    maxWidth: Int?,
+    maxHeight: Int?,
+    tag: String?,
+    imageIndex: Int?,
+  ): String = "https://example.com/images/$itemId/${imageType.apiValue}"
+
+  override suspend fun getResumeItems(
+    limit: Int?,
+    mediaTypes: List<String>?,
+    fields: List<String>?,
+  ) = error("Not used in tests")
+
+  override suspend fun getLatestItems(
+    parentId: String?,
+    includeItemTypes: List<String>?,
+    limit: Int?,
+    fields: List<String>?,
+  ) = error("Not used in tests")
+
+  override suspend fun getNextUpEpisodes(
+    limit: Int?,
+    fields: List<String>?,
+  ) = error("Not used in tests")
+
+  override suspend fun getUserViews() = error("Not used in tests")
+
+  @Suppress("LongParameterList")
+  override suspend fun getItems(
+    parentId: String?,
+    includeItemTypes: List<String>?,
+    sortBy: List<String>?,
+    sortOrder: String?,
+    startIndex: Int?,
+    limit: Int?,
+    recursive: Boolean?,
+    genres: List<String>?,
+    years: List<Int>?,
+    searchTerm: String?,
+    fields: List<String>?,
+  ) = error("Not used in tests")
+
+  override suspend fun getItem(itemId: String) = error("Not used in tests")
+
+  override suspend fun getSimilarItems(
+    itemId: String,
+    limit: Int?,
+  ) = error("Not used in tests")
 }

--- a/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsCompositor.kt
+++ b/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsCompositor.kt
@@ -23,7 +23,7 @@ class ArtistAlbumsCompositor(
     }
 
     return ArtistAlbumsViewState(
-      artistName = modelState.artistName,
+      artist = modelState.artist,
       albums = modelState.albums,
       isLoading = modelState.isLoading,
       error = modelState.error?.toViewError(),
@@ -35,6 +35,7 @@ class ArtistAlbumsCompositor(
     when(intent) {
       ArtistAlbumsIntent.RetryLoad -> albumsModel.loadAlbums(key.artistId)
       is ArtistAlbumsIntent.SelectAlbum -> navigator.navigateToAlbumTracks(intent.albumId)
+      ArtistAlbumsIntent.ToggleFavorite -> Unit // Favorites not yet implemented
       ArtistAlbumsIntent.NavigateBack -> navigator.navigateBack()
     }
   }

--- a/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsIntent.kt
+++ b/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsIntent.kt
@@ -3,5 +3,6 @@ package com.eygraber.jellyfin.screens.music.artist.albums
 sealed interface ArtistAlbumsIntent {
   data object RetryLoad : ArtistAlbumsIntent
   data class SelectAlbum(val albumId: String) : ArtistAlbumsIntent
+  data object ToggleFavorite : ArtistAlbumsIntent
   data object NavigateBack : ArtistAlbumsIntent
 }

--- a/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsView.kt
+++ b/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsView.kt
@@ -1,12 +1,16 @@
 package com.eygraber.jellyfin.screens.music.artist.albums
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -16,19 +20,29 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.eygraber.jellyfin.screens.music.artist.albums.components.ArtistAlbumsGrid
 import com.eygraber.jellyfin.ui.compose.PreviewJellyfinScreen
 import com.eygraber.jellyfin.ui.icons.ArrowBack
+import com.eygraber.jellyfin.ui.icons.FavoriteBorder
 import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+import com.eygraber.jellyfin.ui.icons.MusicNote
 import com.eygraber.jellyfin.ui.material.theme.JellyfinPreviewTheme
 import com.eygraber.jellyfin.ui.material.theme.JellyfinTheme
 import com.eygraber.vice.ViceView
 
 internal typealias ArtistAlbumsView = ViceView<ArtistAlbumsIntent, ArtistAlbumsViewState>
+
+private const val ARTIST_IMAGE_SIZE = 120
+private const val MAX_OVERVIEW_LINES = 4
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,7 +54,7 @@ internal fun ArtistAlbumsView(
     Scaffold(
       topBar = {
         TopAppBar(
-          title = { Text(state.artistName.ifEmpty { "Albums" }) },
+          title = {},
           navigationIcon = {
             IconButton(onClick = { onIntent(ArtistAlbumsIntent.NavigateBack) }) {
               Icon(
@@ -49,6 +63,17 @@ internal fun ArtistAlbumsView(
               )
             }
           },
+          actions = {
+            IconButton(onClick = { onIntent(ArtistAlbumsIntent.ToggleFavorite) }) {
+              Icon(
+                imageVector = JellyfinIcons.FavoriteBorder,
+                contentDescription = "Add to favorites",
+              )
+            }
+          },
+          colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = Color.Transparent,
+          ),
         )
       },
     ) { contentPadding ->
@@ -64,14 +89,99 @@ internal fun ArtistAlbumsView(
             onRetry = { onIntent(ArtistAlbumsIntent.RetryLoad) },
           )
           state.isEmpty -> EmptyContent()
-          else -> ArtistAlbumsGrid(
-            albums = state.albums,
+          else -> ArtistContent(
+            state = state,
             onAlbumClick = { albumId -> onIntent(ArtistAlbumsIntent.SelectAlbum(albumId)) },
           )
         }
       }
     }
   }
+}
+
+@Composable
+internal fun ArtistHeader(
+  artist: ArtistDetail?,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Box(
+      modifier = Modifier
+        .size(ARTIST_IMAGE_SIZE.dp)
+        .clip(CircleShape)
+        .background(MaterialTheme.colorScheme.surfaceVariant),
+      contentAlignment = Alignment.Center,
+    ) {
+      Icon(
+        imageVector = JellyfinIcons.MusicNote,
+        contentDescription = null,
+        modifier = Modifier.size(48.dp),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    artist?.let { artistDetail ->
+      Text(
+        text = artistDetail.name,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+      )
+
+      artistDetail.genre?.let { genre ->
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+          text = genre,
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
+      artistDetail.overview?.let { overview ->
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+          text = overview,
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = MAX_OVERVIEW_LINES,
+          overflow = TextOverflow.Ellipsis,
+        )
+      }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+      text = "Albums",
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.SemiBold,
+      modifier = Modifier.fillMaxWidth(),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+  }
+}
+
+@Composable
+private fun ArtistContent(
+  state: ArtistAlbumsViewState,
+  onAlbumClick: (albumId: String) -> Unit,
+) {
+  ArtistAlbumsGrid(
+    artist = state.artist,
+    albums = state.albums,
+    onAlbumClick = onAlbumClick,
+  )
 }
 
 @Composable
@@ -123,13 +233,20 @@ private fun EmptyContent() {
   }
 }
 
+@Suppress("MagicNumber")
 @PreviewJellyfinScreen
 @Composable
 private fun ArtistAlbumsContentPreview() {
   JellyfinPreviewTheme {
     ArtistAlbumsView(
       state = ArtistAlbumsViewState(
-        artistName = "Pink Floyd",
+        artist = ArtistDetail(
+          id = "artist-1",
+          name = "Pink Floyd",
+          overview = "Pink Floyd were an English rock band formed in London in 1965.",
+          genre = "Progressive Rock",
+          imageUrl = null,
+        ),
         isLoading = false,
         albums = listOf(
           ArtistAlbumItem(

--- a/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsViewState.kt
+++ b/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/ArtistAlbumsViewState.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Immutable
 
 @Immutable
 data class ArtistAlbumsViewState(
-  val artistName: String = "",
+  val artist: ArtistDetail? = null,
   val albums: List<ArtistAlbumItem> = emptyList(),
   val isLoading: Boolean = true,
   val error: ArtistAlbumsError? = null,
@@ -23,6 +23,15 @@ sealed interface ArtistAlbumsError {
     override val message: String = "Unable to connect to server",
   ) : ArtistAlbumsError
 }
+
+@Immutable
+data class ArtistDetail(
+  val id: String,
+  val name: String,
+  val overview: String?,
+  val genre: String?,
+  val imageUrl: String?,
+)
 
 @Immutable
 data class ArtistAlbumItem(

--- a/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/components/ArtistAlbumsGrid.kt
+++ b/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/components/ArtistAlbumsGrid.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Card
@@ -21,20 +22,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.eygraber.jellyfin.screens.music.artist.albums.ArtistAlbumItem
+import com.eygraber.jellyfin.screens.music.artist.albums.ArtistDetail
+import com.eygraber.jellyfin.screens.music.artist.albums.ArtistHeader
+
+private const val GRID_COLUMNS = 2
 
 @Composable
 internal fun ArtistAlbumsGrid(
+  artist: ArtistDetail?,
   albums: List<ArtistAlbumItem>,
   onAlbumClick: (albumId: String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   LazyVerticalGrid(
-    columns = GridCells.Adaptive(minSize = 140.dp),
+    columns = GridCells.Fixed(GRID_COLUMNS),
     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     horizontalArrangement = Arrangement.spacedBy(8.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
     modifier = modifier.fillMaxSize(),
   ) {
+    item(
+      key = "artist-header",
+      span = { GridItemSpan(maxLineSpan) },
+    ) {
+      ArtistHeader(artist = artist)
+    }
+
     items(
       items = albums,
       key = { it.id },

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/FavoriteBorder.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/FavoriteBorder.kt
@@ -1,0 +1,40 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.FavoriteBorder: ImageVector
+  get() {
+    if(internalFavoriteBorder != null) {
+      return requireNotNull(internalFavoriteBorder)
+    }
+    internalFavoriteBorder = materialIcon(name = "Filled.FavoriteBorder") {
+      materialPath {
+        moveTo(16.5f, 3.0f)
+        curveToRelative(-1.74f, 0.0f, -3.41f, 0.81f, -4.5f, 2.09f)
+        curveTo(10.91f, 3.81f, 9.24f, 3.0f, 7.5f, 3.0f)
+        curveTo(4.42f, 3.0f, 2.0f, 5.42f, 2.0f, 8.5f)
+        curveToRelative(0.0f, 3.78f, 3.4f, 6.86f, 8.55f, 11.54f)
+        lineTo(12.0f, 21.35f)
+        lineToRelative(1.45f, -1.32f)
+        curveTo(18.6f, 15.36f, 22.0f, 12.28f, 22.0f, 8.5f)
+        curveTo(22.0f, 5.42f, 19.58f, 3.0f, 16.5f, 3.0f)
+        close()
+        moveTo(12.1f, 18.55f)
+        lineToRelative(-0.1f, 0.1f)
+        lineToRelative(-0.1f, -0.1f)
+        curveTo(7.14f, 14.24f, 4.0f, 11.39f, 4.0f, 8.5f)
+        curveTo(4.0f, 6.5f, 5.5f, 5.0f, 7.5f, 5.0f)
+        curveToRelative(1.54f, 0.0f, 3.04f, 0.99f, 3.57f, 2.36f)
+        horizontalLineToRelative(1.87f)
+        curveTo(13.46f, 5.99f, 14.96f, 5.0f, 16.5f, 5.0f)
+        curveToRelative(2.0f, 0.0f, 3.5f, 1.5f, 3.5f, 3.5f)
+        curveToRelative(0.0f, 2.89f, -3.14f, 5.74f, -7.9f, 10.05f)
+        close()
+      }
+    }
+    return requireNotNull(internalFavoriteBorder)
+  }
+
+private var internalFavoriteBorder: ImageVector? = null

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/MusicNote.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/MusicNote.kt
@@ -1,0 +1,30 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.MusicNote: ImageVector
+  get() {
+    if(internalMusicNote != null) {
+      return requireNotNull(internalMusicNote)
+    }
+    internalMusicNote = materialIcon(name = "Filled.MusicNote") {
+      materialPath {
+        moveTo(12.0f, 3.0f)
+        verticalLineToRelative(10.55f)
+        curveToRelative(-0.59f, -0.34f, -1.27f, -0.55f, -2.0f, -0.55f)
+        curveToRelative(-2.21f, 0.0f, -4.0f, 1.79f, -4.0f, 4.0f)
+        reflectiveCurveToRelative(1.79f, 4.0f, 4.0f, 4.0f)
+        reflectiveCurveToRelative(4.0f, -1.79f, 4.0f, -4.0f)
+        verticalLineTo(7.0f)
+        horizontalLineToRelative(4.0f)
+        verticalLineTo(3.0f)
+        horizontalLineToRelative(-6.0f)
+        close()
+      }
+    }
+    return requireNotNull(internalMusicNote)
+  }
+
+private var internalMusicNote: ImageVector? = null

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Shuffle.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Shuffle.kt
@@ -1,0 +1,44 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.Shuffle: ImageVector
+  get() {
+    if(internalShuffle != null) {
+      return requireNotNull(internalShuffle)
+    }
+    internalShuffle = materialIcon(name = "Filled.Shuffle") {
+      materialPath {
+        moveTo(10.59f, 9.17f)
+        lineTo(5.41f, 4.0f)
+        lineTo(4.0f, 5.41f)
+        lineToRelative(5.17f, 5.17f)
+        lineToRelative(1.42f, -1.41f)
+        close()
+        moveTo(14.5f, 4.0f)
+        lineToRelative(2.04f, 2.04f)
+        lineTo(4.0f, 18.59f)
+        lineTo(5.41f, 20.0f)
+        lineTo(17.96f, 7.46f)
+        lineTo(20.0f, 9.5f)
+        verticalLineTo(4.0f)
+        horizontalLineToRelative(-5.5f)
+        close()
+        moveTo(14.5f, 16.88f)
+        lineTo(13.09f, 15.47f)
+        lineToRelative(2.88f, -2.88f)
+        lineToRelative(1.42f, 1.41f)
+        lineTo(20.0f, 11.5f)
+        verticalLineTo(20.0f)
+        horizontalLineToRelative(-5.5f)
+        lineToRelative(2.04f, -2.04f)
+        lineToRelative(-2.04f, -1.08f)
+        close()
+      }
+    }
+    return requireNotNull(internalShuffle)
+  }
+
+private var internalShuffle: ImageVector? = null


### PR DESCRIPTION
## Summary
- Enhance album detail screen with album artwork header, artist name link, year/genre metadata, Play All and Shuffle buttons, individual track play buttons, and favorite toggle
- Enhance artist detail screen with circular artist image, genre, biography/overview section, favorite toggle, and albums grid with artist header
- Add FavoriteBorder, MusicNote, and Shuffle icons
- Update album tracks navigator to support navigating to artist detail from album screen

Closes #51

## Test plan
- [ ] Album detail shows artwork placeholder, album name, artist link, year, genre
- [ ] Play All and Shuffle buttons render correctly on album detail
- [ ] Individual track rows have play buttons
- [ ] Clicking artist name navigates to artist detail
- [ ] Artist detail shows circular image placeholder, name, genre, overview
- [ ] Albums grid shows below artist header on artist detail
- [ ] Favorite toggle icons appear on both screens
- [ ] Loading and error states work correctly on both screens
- [ ] Unit tests pass for both AlbumTracksModel and ArtistAlbumsModel

🤖 Generated with [Claude Code](https://claude.com/claude-code)