### PR TITLE
#52 Add cast, crew, and similar items to movie detail

### DIFF
--- a/data/items/impl/src/commonMain/kotlin/com/eygraber/jellyfin/data/items/impl/ItemsRemoteDataSource.kt
+++ b/data/items/impl/src/commonMain/kotlin/com/eygraber/jellyfin/data/items/impl/ItemsRemoteDataSource.kt
@@ -5,8 +5,10 @@ import com.eygraber.jellyfin.common.mapSuccessTo
 import com.eygraber.jellyfin.data.items.ItemSortBy
 import com.eygraber.jellyfin.data.items.LibraryItem
 import com.eygraber.jellyfin.data.items.PaginatedResult
+import com.eygraber.jellyfin.data.items.PersonItem
 import com.eygraber.jellyfin.data.items.SortOrder
 import com.eygraber.jellyfin.sdk.core.model.BaseItemDto
+import com.eygraber.jellyfin.sdk.core.model.BaseItemPerson
 import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
 import dev.zacsweers.metro.Inject
 
@@ -84,5 +86,18 @@ private fun BaseItemDto.toLibraryItem(): LibraryItem? {
     seriesId = seriesId,
     childCount = childCount,
     runTimeTicks = runTimeTicks,
+    people = people.mapNotNull { it.toPersonItem() },
+  )
+}
+
+private fun BaseItemPerson.toPersonItem(): PersonItem? {
+  val personId = id ?: return null
+
+  return PersonItem(
+    id = personId,
+    name = name.orEmpty(),
+    role = role,
+    type = type,
+    primaryImageTag = primaryImageTag,
   )
 }

--- a/data/items/public/src/commonMain/kotlin/com/eygraber/jellyfin/data/items/LibraryItem.kt
+++ b/data/items/public/src/commonMain/kotlin/com/eygraber/jellyfin/data/items/LibraryItem.kt
@@ -21,4 +21,16 @@ data class LibraryItem(
   val seriesId: String?,
   val childCount: Int?,
   val runTimeTicks: Long?,
+  val people: List<PersonItem> = emptyList(),
+)
+
+/**
+ * A person associated with a media item (cast member, crew, etc.).
+ */
+data class PersonItem(
+  val id: String,
+  val name: String,
+  val role: String?,
+  val type: String?,
+  val primaryImageTag: String?,
 )

--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
@@ -83,6 +83,9 @@ internal object JellyfinNavigators {
     backStack: NavBackStack<NavKey>,
   ) = MovieDetailNavigator(
     onNavigateBack = { backStack.removeLastOrNull() },
+    onNavigateToSimilarItem = { itemId ->
+      backStack.add(MovieDetailKey(movieId = itemId))
+    },
   )
 
   fun moviesLibrary(

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailCompositor.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailCompositor.kt
@@ -24,6 +24,9 @@ class MovieDetailCompositor(
 
     return MovieDetailViewState(
       movie = modelState.movie,
+      cast = modelState.cast,
+      crew = modelState.crew,
+      similarItems = modelState.similarItems,
       isLoading = modelState.isLoading,
       error = modelState.error?.toViewError(),
     )
@@ -32,6 +35,7 @@ class MovieDetailCompositor(
   override suspend fun onIntent(intent: MovieDetailIntent) {
     when(intent) {
       MovieDetailIntent.RetryLoad -> movieModel.loadMovie(key.movieId)
+      is MovieDetailIntent.SelectSimilarItem -> navigator.navigateToSimilarItem(intent.itemId)
       MovieDetailIntent.NavigateBack -> navigator.navigateBack()
     }
   }

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailIntent.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailIntent.kt
@@ -2,5 +2,6 @@ package com.eygraber.jellyfin.screens.movie.detail
 
 sealed interface MovieDetailIntent {
   data object RetryLoad : MovieDetailIntent
+  data class SelectSimilarItem(val itemId: String) : MovieDetailIntent
   data object NavigateBack : MovieDetailIntent
 }

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailNavigator.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailNavigator.kt
@@ -2,8 +2,13 @@ package com.eygraber.jellyfin.screens.movie.detail
 
 class MovieDetailNavigator(
   private val onNavigateBack: () -> Unit,
+  private val onNavigateToSimilarItem: (itemId: String) -> Unit,
 ) {
   fun navigateBack() {
     onNavigateBack()
+  }
+
+  fun navigateToSimilarItem(itemId: String) {
+    onNavigateToSimilarItem(itemId)
   }
 }

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailView.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailView.kt
@@ -1,9 +1,11 @@
 package com.eygraber.jellyfin.screens.movie.detail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -13,9 +15,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -28,14 +34,17 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.eygraber.jellyfin.ui.compose.PreviewJellyfinScreen
 import com.eygraber.jellyfin.ui.icons.ArrowBack
 import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+import com.eygraber.jellyfin.ui.icons.Person
 import com.eygraber.jellyfin.ui.icons.PlayArrow
 import com.eygraber.jellyfin.ui.icons.Star
 import com.eygraber.jellyfin.ui.material.theme.JellyfinPreviewTheme
@@ -46,6 +55,8 @@ import kotlin.math.roundToInt
 internal typealias MovieDetailView = ViceView<MovieDetailIntent, MovieDetailViewState>
 
 private const val BACKDROP_ASPECT_RATIO = 16F / 9F
+private const val SIMILAR_POSTER_ASPECT_RATIO = 2F / 3F
+private const val PERSON_IMAGE_SIZE = 80
 private const val RATING_DECIMAL_FACTOR = 10
 private const val PLAY_ICON_SIZE = 18
 
@@ -85,7 +96,15 @@ internal fun MovieDetailView(
             error = state.error,
             onRetry = { onIntent(MovieDetailIntent.RetryLoad) },
           )
-          state.movie != null -> MovieContent(movie = state.movie)
+          state.movie != null -> MovieContent(
+            movie = state.movie,
+            cast = state.cast,
+            crew = state.crew,
+            similarItems = state.similarItems,
+            onSimilarItemClick = { itemId ->
+              onIntent(MovieDetailIntent.SelectSimilarItem(itemId))
+            },
+          )
         }
       }
     }
@@ -95,6 +114,10 @@ internal fun MovieDetailView(
 @Composable
 private fun MovieContent(
   movie: MovieDetail,
+  cast: List<CastMember>,
+  crew: List<CrewMember>,
+  similarItems: List<SimilarItem>,
+  onSimilarItemClick: (itemId: String) -> Unit,
 ) {
   Column(
     modifier = Modifier
@@ -149,9 +172,57 @@ private fun MovieContent(
           color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
       }
-
-      Spacer(modifier = Modifier.height(24.dp))
     }
+
+    if(cast.isNotEmpty()) {
+      Spacer(modifier = Modifier.height(24.dp))
+
+      Text(
+        text = "Cast",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = 16.dp),
+      )
+
+      Spacer(modifier = Modifier.height(8.dp))
+
+      CastRow(cast = cast)
+    }
+
+    if(crew.isNotEmpty()) {
+      Spacer(modifier = Modifier.height(24.dp))
+
+      Text(
+        text = "Crew",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = 16.dp),
+      )
+
+      Spacer(modifier = Modifier.height(8.dp))
+
+      CrewRow(crew = crew)
+    }
+
+    if(similarItems.isNotEmpty()) {
+      Spacer(modifier = Modifier.height(24.dp))
+
+      Text(
+        text = "More Like This",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = 16.dp),
+      )
+
+      Spacer(modifier = Modifier.height(8.dp))
+
+      SimilarItemsRow(
+        items = similarItems,
+        onItemClick = onSimilarItemClick,
+      )
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
   }
 }
 
@@ -259,6 +330,160 @@ private fun formatRuntime(minutes: Int): String {
   }
 }
 
+@Composable
+private fun CastRow(
+  cast: List<CastMember>,
+) {
+  LazyRow(
+    contentPadding = PaddingValues(horizontal = 16.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    items(
+      items = cast,
+      key = { it.id },
+    ) { member ->
+      PersonCard(
+        name = member.name,
+        subtitle = member.role,
+      )
+    }
+  }
+}
+
+@Composable
+private fun CrewRow(
+  crew: List<CrewMember>,
+) {
+  LazyRow(
+    contentPadding = PaddingValues(horizontal = 16.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    items(
+      items = crew,
+      key = { it.id },
+    ) { member ->
+      PersonCard(
+        name = member.name,
+        subtitle = member.job,
+      )
+    }
+  }
+}
+
+@Composable
+private fun PersonCard(
+  name: String,
+  subtitle: String?,
+) {
+  Column(
+    horizontalAlignment = Alignment.CenterHorizontally,
+    modifier = Modifier.width(PERSON_IMAGE_SIZE.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(PERSON_IMAGE_SIZE.dp)
+        .clip(CircleShape)
+        .background(MaterialTheme.colorScheme.surfaceVariant),
+      contentAlignment = Alignment.Center,
+    ) {
+      Icon(
+        imageVector = JellyfinIcons.Person,
+        contentDescription = null,
+        modifier = Modifier.size((PERSON_IMAGE_SIZE / 2).dp),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+
+    Spacer(modifier = Modifier.height(4.dp))
+
+    Text(
+      text = name,
+      style = MaterialTheme.typography.labelSmall,
+      maxLines = 2,
+      overflow = TextOverflow.Ellipsis,
+      textAlign = TextAlign.Center,
+    )
+
+    subtitle?.let { subtitleText ->
+      Text(
+        text = subtitleText,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+      )
+    }
+  }
+}
+
+@Composable
+private fun SimilarItemsRow(
+  items: List<SimilarItem>,
+  onItemClick: (itemId: String) -> Unit,
+) {
+  LazyRow(
+    contentPadding = PaddingValues(horizontal = 16.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    items(
+      items = items,
+      key = { it.id },
+    ) { item ->
+      SimilarItemCard(
+        item = item,
+        onClick = { onItemClick(item.id) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun SimilarItemCard(
+  item: SimilarItem,
+  onClick: () -> Unit,
+) {
+  Card(
+    modifier = Modifier
+      .width(120.dp)
+      .clickable(onClick = onClick),
+  ) {
+    Column {
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .aspectRatio(SIMILAR_POSTER_ASPECT_RATIO),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = item.name.take(1),
+          style = MaterialTheme.typography.headlineSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
+      Column(
+        modifier = Modifier.padding(8.dp),
+      ) {
+        Text(
+          text = item.name,
+          style = MaterialTheme.typography.bodySmall,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+
+        item.productionYear?.let { year ->
+          Text(
+            text = year.toString(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+    }
+  }
+}
+
 private fun Float.formatRating(): String {
   val rounded = (this * RATING_DECIMAL_FACTOR).roundToInt()
   return "${rounded / RATING_DECIMAL_FACTOR}.${rounded % RATING_DECIMAL_FACTOR}"
@@ -323,7 +548,7 @@ private fun MovieDetailErrorPreview() {
   }
 }
 
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "LongMethod")
 @PreviewJellyfinScreen
 @Composable
 private fun MovieDetailContentPreview() {
@@ -342,6 +567,19 @@ private fun MovieDetailContentPreview() {
           runtimeMinutes = 148,
           backdropImageUrl = null,
           posterImageUrl = null,
+        ),
+        cast = listOf(
+          CastMember(id = "c1", name = "Leonardo DiCaprio", role = "Cobb", imageUrl = null),
+          CastMember(id = "c2", name = "Joseph Gordon-Levitt", role = "Arthur", imageUrl = null),
+          CastMember(id = "c3", name = "Elliot Page", role = "Ariadne", imageUrl = null),
+        ),
+        crew = listOf(
+          CrewMember(id = "cr1", name = "Christopher Nolan", job = "Director", imageUrl = null),
+          CrewMember(id = "cr2", name = "Hans Zimmer", job = "Music", imageUrl = null),
+        ),
+        similarItems = listOf(
+          SimilarItem(id = "s1", name = "Interstellar", productionYear = 2014, imageUrl = null),
+          SimilarItem(id = "s2", name = "The Matrix", productionYear = 1999, imageUrl = null),
         ),
       ),
       onIntent = {},

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailViewState.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailViewState.kt
@@ -5,6 +5,9 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class MovieDetailViewState(
   val movie: MovieDetail? = null,
+  val cast: List<CastMember> = emptyList(),
+  val crew: List<CrewMember> = emptyList(),
+  val similarItems: List<SimilarItem> = emptyList(),
   val isLoading: Boolean = true,
   val error: MovieDetailError? = null,
 ) {
@@ -33,4 +36,28 @@ data class MovieDetail(
   val runtimeMinutes: Int?,
   val backdropImageUrl: String?,
   val posterImageUrl: String?,
+)
+
+@Immutable
+data class CastMember(
+  val id: String,
+  val name: String,
+  val role: String?,
+  val imageUrl: String?,
+)
+
+@Immutable
+data class CrewMember(
+  val id: String,
+  val name: String,
+  val job: String?,
+  val imageUrl: String?,
+)
+
+@Immutable
+data class SimilarItem(
+  val id: String,
+  val name: String,
+  val productionYear: Int?,
+  val imageUrl: String?,
 )

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Person.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Person.kt
@@ -1,0 +1,32 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.Person: ImageVector
+  get() {
+    if(internalPerson != null) {
+      return requireNotNull(internalPerson)
+    }
+    internalPerson = materialIcon(name = "Filled.Person") {
+      materialPath {
+        moveTo(12.0f, 12.0f)
+        curveToRelative(2.21f, 0.0f, 4.0f, -1.79f, 4.0f, -4.0f)
+        reflectiveCurveToRelative(-1.79f, -4.0f, -4.0f, -4.0f)
+        reflectiveCurveToRelative(-4.0f, 1.79f, -4.0f, 4.0f)
+        reflectiveCurveToRelative(1.79f, 4.0f, 4.0f, 4.0f)
+        close()
+        moveTo(12.0f, 14.0f)
+        curveToRelative(-2.67f, 0.0f, -8.0f, 1.34f, -8.0f, 4.0f)
+        verticalLineToRelative(2.0f)
+        horizontalLineToRelative(16.0f)
+        verticalLineToRelative(-2.0f)
+        curveToRelative(0.0f, -2.66f, -5.33f, -4.0f, -8.0f, -4.0f)
+        close()
+      }
+    }
+    return requireNotNull(internalPerson)
+  }
+
+private var internalPerson: ImageVector? = null


### PR DESCRIPTION
## Summary
- Add `PersonItem` data class to data layer and map from `BaseItemPerson` in remote data source
- Extract cast (actors) and crew (non-actors) from item people data in `MovieDetailModel`
- Display cast and crew in horizontal scrollable sections with circular person placeholders
- Load and display similar items in a "More Like This" horizontal row with poster cards
- Add navigation support for clicking similar items (navigates to another movie detail)
- Add `Person` icon to the UI icons module
- Add comprehensive tests for cast/crew extraction and similar items loading

Closes #52

## Test plan
- [ ] Verify cast section shows actors with names and roles
- [ ] Verify crew section shows non-actor people with names and jobs
- [ ] Verify "More Like This" section shows similar movie poster cards
- [ ] Verify clicking a similar item navigates to that movie's detail screen
- [ ] Verify sections are hidden when no data is available
- [ ] Verify unit tests pass for cast/crew extraction and similar items

🤖 Generated with [Claude Code](https://claude.com/claude-code)