### PR TITLE
#82 Adaptive navigation infrastructure

### DIFF
--- a/.claude/rules/adaptive-design.md
+++ b/.claude/rules/adaptive-design.md
@@ -45,11 +45,14 @@ when (windowSizeClass.windowWidthSizeClass) {
 
 ## Adaptive Navigation
 
-This project uses `material3-adaptive-navigation3` from Compose Multiplatform:
+This project uses `material3-adaptive-navigation-suite` from Compose Multiplatform via
+`JellyfinNavigationSuiteScaffold` in the `nav` module:
 
 ```kotlin
-implementation(libs.compose.nav3.adaptive)
+implementation(libs.compose.material3.adaptiveNavigationSuite)
 ```
+
+To add a new top-level destination, add an entry to `JellyfinTopLevelDestination` (in `nav`).
 
 ## UI Implementation Checklist
 

--- a/.docs/architecture/navigation.md
+++ b/.docs/architecture/navigation.md
@@ -4,17 +4,21 @@ Uses [AndroidX Navigation3](https://developer.android.com/guide/navigation/navig
 
 ## Adaptive Navigation
 
-The app uses `material3-adaptive-navigation3` for form factor-aware navigation:
+The app uses `material3-adaptive-navigation-suite` (via `JellyfinNavigationSuiteScaffold` in the
+`nav` module) for form factor-aware navigation:
 
 ```kotlin
-implementation(libs.compose.nav3.adaptive)
+implementation(libs.compose.material3.adaptiveNavigationSuite)
 ```
 
 | Window Size | Navigation Style        |
-|-------------|------------------------|
-| Compact     | Bottom navigation bar  |
-| Medium      | Navigation rail        |
-| Expanded    | Permanent nav drawer   |
+|-------------|-------------------------|
+| Compact     | Bottom navigation bar   |
+| Medium      | Navigation rail         |
+| Expanded    | Permanent nav drawer    |
+
+The navigation suite is hidden on non-top-level destinations (welcome, detail screens) and
+becomes visible only when the back stack's top-most key is a `JellyfinTopLevelDestination`.
 
 See [Adaptive Design](/.docs/compose/adaptive-design.md) for complete details.
 

--- a/.docs/compose/adaptive-design.md
+++ b/.docs/compose/adaptive-design.md
@@ -20,13 +20,26 @@ This prevents costly rework and ensures a consistent experience across devices.
 
 ## Material 3 Adaptive Components
 
-### Adaptive Navigation (material3-adaptive-navigation3)
+### Adaptive Navigation Suite (material3-adaptive-navigation-suite)
 
-The `material3-adaptive-navigation3` library is available for Compose Multiplatform:
+The `material3-adaptive-navigation-suite` library provides `NavigationSuiteScaffold`, which
+automatically chooses between bottom navigation, navigation rail, and navigation drawer based on
+window size:
 
 ```kotlin
-implementation(libs.compose.nav3.adaptive)
+implementation(libs.compose.material3.adaptiveNavigationSuite)
 ```
+
+This library is wired up in the `nav` module via `JellyfinNavigationSuiteScaffold`, which uses the
+[adaptive breakpoints below](#form-factor-targets) and hides the navigation suite entirely on
+non-top-level destinations (onboarding, detail screens, etc.).
+
+> **Why a separate artifact?** The `compose.nav3.adaptive` artifact
+> (`org.jetbrains.compose.material3.adaptive:adaptive-navigation3`) only contains the
+> `ListDetailSceneStrategy` / `SupportingPaneSceneStrategy` for multi-pane layouts. The
+> `NavigationSuiteScaffold` API lives in the separate
+> `material3-adaptive-navigation-suite` artifact and tracks the same version as the project's
+> `composeMaterial3Jetbrains` (currently `1.11.0-alpha07`).
 
 ### Window Size Classes
 
@@ -90,32 +103,23 @@ fun AdaptiveMediaGrid(
 
 ### Navigation Integration
 
-The app uses `NavigationSuiteScaffold` for adaptive navigation:
+The app uses `JellyfinNavigationSuiteScaffold` (in the `nav` module) which wraps Material's
+`NavigationSuiteScaffold`. The scaffold:
 
-```kotlin
-@Composable
-fun JellyfinApp() {
-  NavigationSuiteScaffold(
-    navigationSuiteItems = {
-      item(
-        selected = currentRoute == "home",
-        onClick = { navigateTo("home") },
-        icon = { Icon(Icons.Default.Home, "Home") },
-        label = { Text("Home") },
-      )
-      // ... more items
-    },
-  ) {
-    // Screen content
-    NavHost(...)
-  }
-}
-```
+- Reads the current top-most key from the `NavBackStack`
+- Resolves it to a `JellyfinTopLevelDestination` (Home, Search, ...) and marks it selected
+- Replaces the entire back stack with the destination key when an item is tapped
+- Renders **no navigation surface** when the top-most key is not a top-level destination
+  (e.g. on the splash, welcome, or any detail screen) so onboarding and detail flows render
+  full-bleed
 
 The scaffold automatically switches between:
-- **Bottom navigation** on compact windows
-- **Navigation rail** on medium windows
-- **Navigation drawer** on expanded windows
+- **Bottom navigation** on compact windows (< 600dp)
+- **Navigation rail** on medium windows (600-840dp)
+- **Permanent navigation drawer** on expanded windows (> 840dp)
+
+To add a new top-level destination, add an entry to `JellyfinTopLevelDestination` with the screen's
+`NavKey`, an `ImageVector` icon, and a `StringResource` label.
 
 ## Input Method Considerations
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,6 +143,7 @@ compose-edgeToEdgePreview = "de.drick.compose:edge-to-edge-preview:0.9.0"
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeJetbrains" }
 compose-foundationLayout = { module = "org.jetbrains.compose.foundation:foundation-layout", version.ref = "composeJetbrains" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMaterial3Jetbrains" }
+compose-material3-adaptiveNavigationSuite = { module = "org.jetbrains.compose.material3:material3-adaptive-navigation-suite", version.ref = "composeMaterial3Jetbrains" }
 compose-materialIcons = { module = "org.jetbrains.compose.material:material-icons-core", version = "1.7.3" }
 compose-nav3-adaptive = "org.jetbrains.compose.material3.adaptive:adaptive-navigation3:1.3.0-alpha07"
 compose-nav3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidx-nav3" }

--- a/nav/build.gradle.kts
+++ b/nav/build.gradle.kts
@@ -9,10 +9,18 @@ plugins {
   alias(libs.plugins.metro)
 }
 
+val pkg = "com.eygraber.jellyfin.nav"
+
+compose {
+  resources {
+    packageOfResClass = pkg
+  }
+}
+
 kotlin {
   defaultKmpTargets(
     project = project,
-    androidNamespace = "com.eygraber.jellyfin.nav",
+    androidNamespace = pkg,
   )
 
   sourceSets {
@@ -39,6 +47,8 @@ kotlin {
       implementation(projects.screens.tvshowSeasons)
       implementation(projects.screens.welcome)
 
+      implementation(projects.ui.icons)
+
       api(projects.services.deviceSensors.public)
 
       implementation(libs.compose.nav3.runtime)
@@ -46,6 +56,8 @@ kotlin {
 
       implementation(libs.compose.animation)
       implementation(libs.compose.material3)
+      implementation(libs.compose.material3.adaptiveNavigationSuite)
+      implementation(libs.compose.resources)
       implementation(libs.compose.runtime)
       implementation(libs.compose.ui)
 

--- a/nav/src/commonMain/composeResources/values/strings.xml
+++ b/nav/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="nav_home">Home</string>
+  <string name="nav_search">Search</string>
+</resources>

--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNav.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNav.kt
@@ -103,37 +103,41 @@ fun JellyfinNav(
     CompositionLocalProvider(
       LocalSharedTransitionScope provides this,
     ) {
-      NavDisplay(
+      JellyfinNavigationSuiteScaffold(
         backStack = backStack,
         modifier = modifier,
-        sceneStrategies = listOf(
-          DialogSceneStrategy(),
-          BottomSheetSceneStrategy(),
-          SinglePaneSceneStrategy(),
-        ),
-        transitionSpec = {
-          ContentTransform(
-            targetContentEnter = slideInHorizontally(screenTransitionSpec) { it * 2 },
-            initialContentExit = slideOutHorizontally(screenTransitionSpec) { -it },
-          )
-        },
-        popTransitionSpec = {
-          ContentTransform(
-            targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
-            initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
-          )
-        },
-        predictivePopTransitionSpec = { _ ->
-          ContentTransform(
-            targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
-            initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
-          )
-        },
-        onBack = { backStack.removeLastOrNull() },
-        entryProvider = remember(navGraph, backStack) {
-          jellyfinNavEntryProvider(navGraph, backStack)
-        },
-      )
+      ) {
+        NavDisplay(
+          backStack = backStack,
+          sceneStrategies = listOf(
+            DialogSceneStrategy(),
+            BottomSheetSceneStrategy(),
+            SinglePaneSceneStrategy(),
+          ),
+          transitionSpec = {
+            ContentTransform(
+              targetContentEnter = slideInHorizontally(screenTransitionSpec) { it * 2 },
+              initialContentExit = slideOutHorizontally(screenTransitionSpec) { -it },
+            )
+          },
+          popTransitionSpec = {
+            ContentTransform(
+              targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
+              initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
+            )
+          },
+          predictivePopTransitionSpec = { _ ->
+            ContentTransform(
+              targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
+              initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
+            )
+          },
+          onBack = { backStack.removeLastOrNull() },
+          entryProvider = remember(navGraph, backStack) {
+            jellyfinNavEntryProvider(navGraph, backStack)
+          },
+        )
+      }
     }
   }
 }

--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffold.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffold.kt
@@ -1,0 +1,112 @@
+package com.eygraber.jellyfin.nav
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.WindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.window.core.layout.WindowSizeClass
+
+/**
+ * Navigation suite scaffold for the Jellyfin app.
+ *
+ * Displays a [NavigationSuiteScaffold] around [content] that automatically switches between bottom
+ * navigation, navigation rail, and navigation drawer based on the current window size:
+ *
+ * | Window Width | Navigation Style       |
+ * |--------------|------------------------|
+ * | < 600dp      | Bottom navigation bar  |
+ * | 600 - 840dp  | Navigation rail        |
+ * | > 840dp      | Permanent nav drawer   |
+ *
+ * The navigation suite is only shown when the current top-most entry on [backStack] is a known
+ * [JellyfinTopLevelDestination]. Onboarding (root, welcome) and detail screens render full-bleed
+ * without a navigation surface.
+ *
+ * Tapping a navigation item replaces the entire back stack with the destination's key. This keeps
+ * top-level switches predictable on all form factors and prevents stacking duplicate destinations.
+ */
+@Composable
+internal fun JellyfinNavigationSuiteScaffold(
+  backStack: NavBackStack<NavKey>,
+  modifier: Modifier = Modifier,
+  windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
+  content: @Composable () -> Unit,
+) {
+  val currentTopLevelDestination = remember(backStack.lastOrNull()) {
+    JellyfinTopLevelDestination.forKey(backStack.lastOrNull())
+  }
+
+  val navigationSuiteType = if(currentTopLevelDestination == null) {
+    NavigationSuiteType.None
+  }
+  else {
+    jellyfinNavigationSuiteType(windowAdaptiveInfo)
+  }
+
+  // Labels must be resolved in a composable scope; navigationSuiteItems is a non-composable
+  // builder lambda.
+  val labels = JellyfinTopLevelDestination.entries.associateWith { it.label() }
+
+  NavigationSuiteScaffold(
+    navigationSuiteItems = {
+      JellyfinTopLevelDestination.entries.forEach { destination ->
+        val label = labels.getValue(destination)
+        item(
+          selected = destination == currentTopLevelDestination,
+          onClick = { onTopLevelDestinationSelected(backStack, destination) },
+          icon = {
+            Icon(
+              imageVector = destination.icon,
+              // The adjacent Text label is read by accessibility services, so the icon's
+              // contentDescription is intentionally null to avoid duplicate announcements.
+              contentDescription = null,
+            )
+          },
+          label = { Text(label) },
+        )
+      }
+    },
+    modifier = modifier,
+    layoutType = navigationSuiteType,
+    content = content,
+  )
+}
+
+private fun onTopLevelDestinationSelected(
+  backStack: NavBackStack<NavKey>,
+  destination: JellyfinTopLevelDestination,
+) {
+  if(backStack.lastOrNull() == destination.key) return
+  backStack.clear()
+  backStack.add(destination.key)
+}
+
+/**
+ * Resolves the active [NavigationSuiteType] using the project's adaptive breakpoints.
+ *
+ * Material's recommended `navigationSuiteType` defaults to `ShortNavigationBar*` and
+ * `WideNavigationRailCollapsed`. The project's design language calls for a permanent navigation
+ * drawer at expanded widths and a navigation rail at medium widths, so we compute the type
+ * directly from [WindowSizeClass] breakpoints (600dp, 840dp).
+ */
+private fun jellyfinNavigationSuiteType(
+  windowAdaptiveInfo: WindowAdaptiveInfo,
+): NavigationSuiteType {
+  val sizeClass = windowAdaptiveInfo.windowSizeClass
+  return when {
+    sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) ->
+      NavigationSuiteType.NavigationDrawer
+
+    sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND) ->
+      NavigationSuiteType.NavigationRail
+
+    else -> NavigationSuiteType.NavigationBar
+  }
+}

--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestination.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestination.kt
@@ -1,0 +1,48 @@
+package com.eygraber.jellyfin.nav
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation3.runtime.NavKey
+import com.eygraber.jellyfin.screens.home.HomeKey
+import com.eygraber.jellyfin.screens.search.SearchKey
+import com.eygraber.jellyfin.ui.icons.JellyfinIcons
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import com.eygraber.jellyfin.ui.icons.Home as HomeIcon
+import com.eygraber.jellyfin.ui.icons.Search as SearchIcon
+
+/**
+ * Top-level destinations rendered as items in the [JellyfinNavigationSuiteScaffold].
+ *
+ * A destination is considered top-level when it is reachable directly from the navigation suite
+ * (bottom bar / rail / drawer) and should always reset the back stack to the destination's [key]
+ * when selected.
+ */
+internal enum class JellyfinTopLevelDestination(
+  val key: NavKey,
+  val icon: ImageVector,
+  val label: StringResource,
+) {
+  Home(
+    key = HomeKey,
+    icon = JellyfinIcons.HomeIcon,
+    label = Res.string.nav_home,
+  ),
+  Search(
+    key = SearchKey,
+    icon = JellyfinIcons.SearchIcon,
+    label = Res.string.nav_search,
+  ),
+  ;
+
+  @Composable
+  fun label(): String = stringResource(label)
+
+  companion object {
+    /**
+     * Returns the [JellyfinTopLevelDestination] that owns the given [key], or `null` if the key
+     * does not correspond to a top-level destination (e.g. detail or onboarding screens).
+     */
+    fun forKey(key: NavKey?): JellyfinTopLevelDestination? = entries.firstOrNull { it.key == key }
+  }
+}

--- a/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestinationTest.kt
+++ b/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestinationTest.kt
@@ -1,0 +1,34 @@
+package com.eygraber.jellyfin.nav
+
+import com.eygraber.jellyfin.screens.home.HomeKey
+import com.eygraber.jellyfin.screens.movie.detail.MovieDetailKey
+import com.eygraber.jellyfin.screens.root.RootKey
+import com.eygraber.jellyfin.screens.search.SearchKey
+import com.eygraber.jellyfin.screens.welcome.WelcomeKey
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class JellyfinTopLevelDestinationTest {
+  @Test
+  fun `forKey - returns Home for HomeKey`() {
+    JellyfinTopLevelDestination.forKey(HomeKey) shouldBe JellyfinTopLevelDestination.Home
+  }
+
+  @Test
+  fun `forKey - returns Search for SearchKey`() {
+    JellyfinTopLevelDestination.forKey(SearchKey) shouldBe JellyfinTopLevelDestination.Search
+  }
+
+  @Test
+  fun `forKey - returns null for non top-level destinations`() {
+    JellyfinTopLevelDestination.forKey(RootKey).shouldBeNull()
+    JellyfinTopLevelDestination.forKey(WelcomeKey).shouldBeNull()
+    JellyfinTopLevelDestination.forKey(MovieDetailKey(movieId = "id")).shouldBeNull()
+  }
+
+  @Test
+  fun `forKey - returns null when key is null`() {
+    JellyfinTopLevelDestination.forKey(null).shouldBeNull()
+  }
+}

--- a/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Home.kt
+++ b/ui/icons/src/commonMain/kotlin/com/eygraber/jellyfin/ui/icons/Home.kt
@@ -1,0 +1,31 @@
+package com.eygraber.jellyfin.ui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val JellyfinIcons.Home: ImageVector
+  get() {
+    if(internalHome != null) {
+      return requireNotNull(internalHome)
+    }
+    internalHome = materialIcon(name = "Filled.Home") {
+      materialPath {
+        moveTo(10.0f, 20.0f)
+        verticalLineToRelative(-6.0f)
+        horizontalLineToRelative(4.0f)
+        verticalLineToRelative(6.0f)
+        horizontalLineToRelative(5.0f)
+        verticalLineToRelative(-8.0f)
+        horizontalLineToRelative(3.0f)
+        lineTo(12.0f, 3.0f)
+        lineTo(2.0f, 12.0f)
+        horizontalLineToRelative(3.0f)
+        verticalLineToRelative(8.0f)
+        close()
+      }
+    }
+    return requireNotNull(internalHome)
+  }
+
+private var internalHome: ImageVector? = null


### PR DESCRIPTION
Closes #82

## Summary

- Wires up `material3-adaptive-navigation-suite` as `JellyfinNavigationSuiteScaffold` in the `nav` module so screens can render inside an adaptive navigation surface that switches between bottom navigation (< 600dp), navigation rail (600-840dp), and permanent navigation drawer (> 840dp).
- Hides the navigation surface on non-top-level destinations (welcome, detail screens, dialogs, etc.) so onboarding and detail flows still render full-bleed.
- Top-level destinations are declared as `JellyfinTopLevelDestination` enum entries (initially Home and Search) so adding new destinations is a one-line change.

## Notes

- Used `org.jetbrains.compose.material3:material3-adaptive-navigation-suite` (which contains `NavigationSuiteScaffold`) rather than `org.jetbrains.compose.material3.adaptive:adaptive-navigation3` (which only contains `ListDetail`/`SupportingPane` scene strategies). Both libraries have similar names but different APIs - documented in `.docs/compose/adaptive-design.md`.
- The library version is pinned to `composeMaterial3Jetbrains` (`1.11.0-alpha07`), which already aligns with the rest of the project's CMP material3 stack.
- Window size class breakpoints come from `androidx.window.core.layout.WindowSizeClass.WIDTH_DP_*_LOWER_BOUND` constants.
- Added a `Home` icon to `ui/icons` and `nav_home` / `nav_search` strings to the new `nav` module compose resources.

## Test plan

- [x] `./check` passes
- [x] `:nav:compileAndroidMain`, `:nav:compileKotlinJvm`, `:nav:compileKotlinIosSimulatorArm64`, `:nav:compileKotlinWasmJs` all succeed
- [x] `:nav:jvmTest` passes (added `JellyfinTopLevelDestinationTest`)
- [x] `:nav:detektAll` passes
- [x] `:apps:android:assembleDevDebug` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)