### PR TITLE
#213 Fix navigation scaffold flash during top-level transitions

### DIFF
--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNav.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNav.kt
@@ -74,6 +74,16 @@ import kotlinx.serialization.modules.polymorphic
 
 private val screenTransitionSpec: FiniteAnimationSpec<IntOffset> = tween(400)
 
+/**
+ * Root navigation host for the Jellyfin app.
+ *
+ * The navigation suite (bottom bar / rail / drawer) is rendered by
+ * [TopLevelDestinationSceneStrategy] inside the [NavDisplay] rather than wrapping the [NavDisplay]
+ * itself. Sharing a single scene across all top-level destinations keeps the navigation suite
+ * mounted across top-level transitions, so only the inner content animates and the scaffold does
+ * not flash. Transitions to and from non-top-level destinations still animate through the standard
+ * scene-level transition specs configured here.
+ */
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun JellyfinNav(
@@ -101,47 +111,56 @@ fun JellyfinNav(
     backStack = backStack,
   )
 
-  SharedTransitionLayout {
+  SharedTransitionLayout(modifier = modifier) {
     CompositionLocalProvider(
       LocalSharedTransitionScope provides this,
     ) {
-      JellyfinNavigationSuiteScaffold(
+      NavDisplay(
         backStack = backStack,
-        modifier = modifier,
-      ) {
-        NavDisplay(
-          backStack = backStack,
-          sceneStrategies = listOf(
-            DialogSceneStrategy(),
-            BottomSheetSceneStrategy(),
-            SinglePaneSceneStrategy(),
+        sceneStrategies = listOf(
+          DialogSceneStrategy(),
+          BottomSheetSceneStrategy(),
+          TopLevelDestinationSceneStrategy(
+            onTopLevelDestinationSelected = { destination ->
+              onTopLevelDestinationSelected(backStack, destination)
+            },
           ),
-          transitionSpec = {
-            ContentTransform(
-              targetContentEnter = slideInHorizontally(screenTransitionSpec) { it * 2 },
-              initialContentExit = slideOutHorizontally(screenTransitionSpec) { -it },
-            )
-          },
-          popTransitionSpec = {
-            ContentTransform(
-              targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
-              initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
-            )
-          },
-          predictivePopTransitionSpec = { _ ->
-            ContentTransform(
-              targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
-              initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
-            )
-          },
-          onBack = { backStack.removeLastOrNull() },
-          entryProvider = remember(navGraph, backStack) {
-            jellyfinNavEntryProvider(navGraph, backStack)
-          },
-        )
-      }
+          SinglePaneSceneStrategy(),
+        ),
+        transitionSpec = {
+          ContentTransform(
+            targetContentEnter = slideInHorizontally(screenTransitionSpec) { it * 2 },
+            initialContentExit = slideOutHorizontally(screenTransitionSpec) { -it },
+          )
+        },
+        popTransitionSpec = {
+          ContentTransform(
+            targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
+            initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
+          )
+        },
+        predictivePopTransitionSpec = { _ ->
+          ContentTransform(
+            targetContentEnter = slideInHorizontally(screenTransitionSpec) { -it },
+            initialContentExit = slideOutHorizontally(screenTransitionSpec) { it * 2 },
+          )
+        },
+        onBack = { backStack.removeLastOrNull() },
+        entryProvider = remember(navGraph, backStack) {
+          jellyfinNavEntryProvider(navGraph, backStack)
+        },
+      )
     }
   }
+}
+
+private fun onTopLevelDestinationSelected(
+  backStack: NavBackStack<NavKey>,
+  destination: JellyfinTopLevelDestination,
+) {
+  if(backStack.lastOrNull() == destination.key) return
+  backStack.clear()
+  backStack.add(destination.key)
 }
 
 private fun jellyfinNavEntryProvider(

--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffold.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffold.kt
@@ -7,10 +7,7 @@ import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.navigation3.runtime.NavBackStack
-import androidx.navigation3.runtime.NavKey
 import androidx.window.core.layout.WindowSizeClass
 
 /**
@@ -25,31 +22,23 @@ import androidx.window.core.layout.WindowSizeClass
  * | 600 - 840dp  | Navigation rail        |
  * | > 840dp      | Permanent nav drawer   |
  *
- * The navigation suite is only shown when the current top-most entry on [backStack] is a known
- * [JellyfinTopLevelDestination]. Onboarding (root, welcome) and detail screens render full-bleed
- * without a navigation surface.
+ * This composable assumes it is only rendered when a top-level destination is active; the
+ * containing [TopLevelDestinationScene] is responsible for that gating. Callers pass the active
+ * [currentTopLevelDestination] (which drives the selected highlight) and a click handler that
+ * receives the chosen destination.
  *
- * Tapping a navigation item replaces the entire back stack with the destination's key. This keeps
- * top-level switches predictable on all form factors and prevents stacking duplicate destinations.
+ * Keeping this composable inside a scene that is shared across top-level destinations means the
+ * navigation suite stays mounted while inner content swaps, avoiding the visual flash of the
+ * scaffold animating between destinations.
  */
 @Composable
 internal fun JellyfinNavigationSuiteScaffold(
-  backStack: NavBackStack<NavKey>,
+  currentTopLevelDestination: JellyfinTopLevelDestination?,
+  onSelectTopLevelDestination: (JellyfinTopLevelDestination) -> Unit,
   modifier: Modifier = Modifier,
   windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
   content: @Composable () -> Unit,
 ) {
-  val currentTopLevelDestination = remember(backStack.lastOrNull()) {
-    JellyfinTopLevelDestination.forKey(backStack.lastOrNull())
-  }
-
-  val navigationSuiteType = if(currentTopLevelDestination == null) {
-    NavigationSuiteType.None
-  }
-  else {
-    jellyfinNavigationSuiteType(windowAdaptiveInfo)
-  }
-
   // Labels must be resolved in a composable scope; navigationSuiteItems is a non-composable
   // builder lambda.
   val labels = JellyfinTopLevelDestination.entries.associateWith { it.label() }
@@ -60,7 +49,7 @@ internal fun JellyfinNavigationSuiteScaffold(
         val label = labels.getValue(destination)
         item(
           selected = destination == currentTopLevelDestination,
-          onClick = { onTopLevelDestinationSelected(backStack, destination) },
+          onClick = { onSelectTopLevelDestination(destination) },
           icon = {
             Icon(
               imageVector = destination.icon,
@@ -74,18 +63,9 @@ internal fun JellyfinNavigationSuiteScaffold(
       }
     },
     modifier = modifier,
-    layoutType = navigationSuiteType,
+    layoutType = jellyfinNavigationSuiteType(windowAdaptiveInfo),
     content = content,
   )
-}
-
-private fun onTopLevelDestinationSelected(
-  backStack: NavBackStack<NavKey>,
-  destination: JellyfinTopLevelDestination,
-) {
-  if(backStack.lastOrNull() == destination.key) return
-  backStack.clear()
-  backStack.add(destination.key)
 }
 
 /**

--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestination.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestination.kt
@@ -35,6 +35,14 @@ internal enum class JellyfinTopLevelDestination(
   ),
   ;
 
+  /**
+   * The default `contentKey` for a [androidx.navigation3.runtime.NavEntry] built from this
+   * destination's [key]. Vice's `viceEntry` derives the content key by calling `key.toString()`,
+   * which matches `NavEntry`'s default; this property mirrors that derivation so callers that only
+   * have access to a `NavEntry.contentKey` can still resolve the destination.
+   */
+  val contentKey: Any = key.toString()
+
   @Composable
   fun label(): String = stringResource(label)
 
@@ -44,5 +52,15 @@ internal enum class JellyfinTopLevelDestination(
      * does not correspond to a top-level destination (e.g. detail or onboarding screens).
      */
     fun forKey(key: NavKey?): JellyfinTopLevelDestination? = entries.firstOrNull { it.key == key }
+
+    /**
+     * Returns the [JellyfinTopLevelDestination] whose [contentKey] matches [contentKey], or `null`
+     * if no destination is associated with that content key.
+     *
+     * Useful when only an entry's `contentKey` is accessible (e.g. inside a custom `Scene`), since
+     * `NavEntry.key` itself is not part of the public API.
+     */
+    fun forContentKey(contentKey: Any?): JellyfinTopLevelDestination? =
+      entries.firstOrNull { it.contentKey == contentKey }
   }
 }

--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/TopLevelDestinationSceneStrategy.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/TopLevelDestinationSceneStrategy.kt
@@ -1,0 +1,105 @@
+package com.eygraber.jellyfin.nav
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+
+/**
+ * A [Scene] that renders a single top-level [NavEntry] inside the
+ * [JellyfinNavigationSuiteScaffold].
+ *
+ * All instances of this scene share the same [SCENE_KEY], which means
+ * [androidx.navigation3.ui.NavDisplay] treats transitions between top-level destinations as the
+ * same scene. As a result the surrounding navigation suite (bottom bar / rail / drawer) stays
+ * stable across these transitions and only the inner entry content animates via the nested
+ * [AnimatedContent] inside [content].
+ *
+ * Transitions to and from non-top-level destinations (detail / onboarding screens) still go
+ * through a different scene, so the navigation suite participates in the standard scene-level
+ * animation in those cases.
+ */
+@Immutable
+internal class TopLevelDestinationScene(
+  private val entry: NavEntry<NavKey>,
+  override val previousEntries: List<NavEntry<NavKey>>,
+  private val onTopLevelDestinationSelected: (JellyfinTopLevelDestination) -> Unit,
+) : Scene<NavKey> {
+  override val key: Any = SCENE_KEY
+
+  override val entries: List<NavEntry<NavKey>> = listOf(entry)
+
+  override val content: @Composable () -> Unit = {
+    JellyfinNavigationSuiteScaffold(
+      currentTopLevelDestination = JellyfinTopLevelDestination.forContentKey(entry.contentKey),
+      onSelectTopLevelDestination = onTopLevelDestinationSelected,
+    ) {
+      AnimatedContent(
+        targetState = entry,
+        contentKey = { it.contentKey },
+        transitionSpec = {
+          fadeIn(topLevelTransitionSpec) togetherWith fadeOut(topLevelTransitionSpec)
+        },
+        label = "top-level-destination",
+      ) { targetEntry ->
+        targetEntry.Content()
+      }
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if(this === other) return true
+    if(other !is TopLevelDestinationScene) return false
+
+    return entry == other.entry &&
+      previousEntries == other.previousEntries
+  }
+
+  override fun hashCode(): Int {
+    var result = entry.hashCode()
+    result = 31 * result + previousEntries.hashCode()
+    return result
+  }
+
+  companion object {
+    /**
+     * A constant key shared by every [TopLevelDestinationScene] so that the navigation suite is
+     * preserved across top-level destination changes. NavDisplay identifies a scene by its
+     * `(class, key)` pair, and a stable key tells it that switching between top-level entries is
+     * not a scene transition.
+     */
+    internal const val SCENE_KEY: String = "jellyfin-top-level-destination"
+
+    private val topLevelTransitionSpec = tween<Float>(durationMillis = 200)
+  }
+}
+
+/**
+ * Returns a [TopLevelDestinationScene] when the top of the back stack is a known
+ * [JellyfinTopLevelDestination] (e.g. Home, Search). Returns `null` for any other entry, allowing
+ * the next [SceneStrategy] in the chain to handle it.
+ */
+internal class TopLevelDestinationSceneStrategy(
+  private val onTopLevelDestinationSelected: (JellyfinTopLevelDestination) -> Unit,
+) : SceneStrategy<NavKey> {
+  override fun SceneStrategyScope<NavKey>.calculateScene(
+    entries: List<NavEntry<NavKey>>,
+  ): Scene<NavKey>? {
+    val lastEntry = entries.lastOrNull() ?: return null
+    if(JellyfinTopLevelDestination.forContentKey(lastEntry.contentKey) == null) return null
+
+    return TopLevelDestinationScene(
+      entry = lastEntry,
+      previousEntries = entries.dropLast(1),
+      onTopLevelDestinationSelected = onTopLevelDestinationSelected,
+    )
+  }
+}

--- a/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestinationTest.kt
+++ b/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/JellyfinTopLevelDestinationTest.kt
@@ -31,4 +31,29 @@ class JellyfinTopLevelDestinationTest {
   fun `forKey - returns null when key is null`() {
     JellyfinTopLevelDestination.forKey(null).shouldBeNull()
   }
+
+  @Test
+  fun `forContentKey - returns Home for HomeKey contentKey`() {
+    JellyfinTopLevelDestination.forContentKey(HomeKey.toString()) shouldBe
+      JellyfinTopLevelDestination.Home
+  }
+
+  @Test
+  fun `forContentKey - returns Search for SearchKey contentKey`() {
+    JellyfinTopLevelDestination.forContentKey(SearchKey.toString()) shouldBe
+      JellyfinTopLevelDestination.Search
+  }
+
+  @Test
+  fun `forContentKey - returns null for non top-level contentKeys`() {
+    JellyfinTopLevelDestination.forContentKey(RootKey.toString()).shouldBeNull()
+    JellyfinTopLevelDestination.forContentKey(WelcomeKey.toString()).shouldBeNull()
+    JellyfinTopLevelDestination.forContentKey(MovieDetailKey(movieId = "id").toString())
+      .shouldBeNull()
+  }
+
+  @Test
+  fun `forContentKey - returns null when contentKey is null`() {
+    JellyfinTopLevelDestination.forContentKey(null).shouldBeNull()
+  }
 }

--- a/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/TopLevelDestinationSceneStrategyTest.kt
+++ b/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/TopLevelDestinationSceneStrategyTest.kt
@@ -1,0 +1,99 @@
+package com.eygraber.jellyfin.nav
+
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.scene.SceneStrategyScope
+import com.eygraber.jellyfin.screens.home.HomeKey
+import com.eygraber.jellyfin.screens.movie.detail.MovieDetailKey
+import com.eygraber.jellyfin.screens.root.RootKey
+import com.eygraber.jellyfin.screens.search.SearchKey
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+class TopLevelDestinationSceneStrategyTest {
+  private val strategy = TopLevelDestinationSceneStrategy(
+    onTopLevelDestinationSelected = {},
+  )
+
+  @Test
+  fun `calculateScene - returns scene when last entry is HomeKey`() {
+    val entries = listOf(navEntry(HomeKey))
+
+    val scene = strategy.calculate(entries)
+
+    scene.shouldBeInstanceOf<TopLevelDestinationScene>()
+    scene.key shouldBe TopLevelDestinationScene.SCENE_KEY
+    scene.entries.size shouldBe 1
+    scene.previousEntries.shouldBeEmpty()
+  }
+
+  @Test
+  fun `calculateScene - returns scene when last entry is SearchKey`() {
+    val entries = listOf(navEntry(SearchKey))
+
+    val scene = strategy.calculate(entries)
+
+    scene.shouldBeInstanceOf<TopLevelDestinationScene>()
+  }
+
+  @Test
+  fun `calculateScene - shares the same key across top-level destinations`() {
+    val homeScene = strategy.calculate(listOf(navEntry(HomeKey)))
+    val searchScene = strategy.calculate(listOf(navEntry(SearchKey)))
+
+    homeScene?.key shouldBe searchScene?.key
+  }
+
+  @Test
+  fun `calculateScene - returns null when last entry is non-top-level`() {
+    val entries = listOf(
+      navEntry(HomeKey),
+      navEntry(MovieDetailKey(movieId = "id")),
+    )
+
+    val scene = strategy.calculate(entries)
+
+    scene.shouldBeNull()
+  }
+
+  @Test
+  fun `calculateScene - returns null when last entry is RootKey`() {
+    val entries = listOf(navEntry(RootKey))
+
+    val scene = strategy.calculate(entries)
+
+    scene.shouldBeNull()
+  }
+
+  @Test
+  fun `calculateScene - returns null when entries is empty`() {
+    val entries = emptyList<NavEntry<NavKey>>()
+
+    val scene = strategy.calculate(entries)
+
+    scene.shouldBeNull()
+  }
+
+  @Test
+  fun `calculateScene - sets previousEntries to all but last entry`() {
+    val rootEntry = navEntry(RootKey)
+    val entries = listOf(rootEntry, navEntry(HomeKey))
+
+    val scene = strategy.calculate(entries)
+
+    scene.shouldBeInstanceOf<TopLevelDestinationScene>()
+    scene.previousEntries shouldBe listOf(rootEntry)
+  }
+
+  private fun TopLevelDestinationSceneStrategy.calculate(
+    entries: List<NavEntry<NavKey>>,
+  ) = with(this) { SceneStrategyScope<NavKey>().calculateScene(entries) }
+
+  private fun navEntry(key: NavKey): NavEntry<NavKey> = NavEntry(
+    key = key,
+    content = {},
+  )
+}


### PR DESCRIPTION
Closes #213

## Summary

- Add `TopLevelDestinationSceneStrategy` that wraps top-level destinations (Home, Search) in a custom `Scene` with a constant key, so navigating between them is not seen as a scene transition by `NavDisplay`. The navigation suite (bottom bar / rail / drawer) stays mounted and only the inner entry fades in/out via a nested `AnimatedContent`.
- Refactor `JellyfinNavigationSuiteScaffold` to receive the active destination and click handler directly; the scene now owns rendering it.
- Add `JellyfinTopLevelDestination.forContentKey(...)` and `contentKey` property so a destination can be resolved from a `NavEntry.contentKey` (since `NavEntry.key` is not part of the public API).

Transitions to and from non-top-level destinations (root, welcome, login, detail screens) still animate the full scaffold through the existing scene-level transition specs configured on `NavDisplay`.

## Test plan
- [x] `./check` passes locally
- [x] New unit tests cover `TopLevelDestinationSceneStrategy` (top-level vs non-top-level entries, shared scene key, previousEntries) and `JellyfinTopLevelDestination.forContentKey`
- [ ] Manual: switching between Home and Search shows no flash on the bottom nav / nav rail / nav drawer
- [ ] Manual: navigating from Home to a detail screen still animates the scaffold out, and back animates it in
- [ ] Manual: predictive back from a detail screen back to a top-level destination still works on Android
- [ ] Manual: behavior consistent across Android, iOS, Desktop, and Web targets