### PR TITLE
#216 Clarify In Review → Done transition

### DIFF
--- a/.claude/rules/project-management.md
+++ b/.claude/rules/project-management.md
@@ -104,7 +104,7 @@ To find current work manually:
 **Rules:**
 - When starting work: Move to **In Progress** before writing code
 - When creating a PR: Move to **In Review**
-- When completing work: Close the issue (automatically moves to Done)
+- When a PR merges: The linked issue should land in **Done**. Closing keywords (`Closes #N`) auto-close the issue and move it to Done. If the auto-close didn't fire (no closing keyword, or the field didn't update), close the issue or move it to Done manually — agents are expected to perform this transition rather than leave merged work in In Review.
 - When work is interrupted: Leave in **In Progress** (use `/resume-work` to continue)
 - When a blocker is removed: Move unblocked issues from Backlog to **Ready**
 - **Never move issues out of Done** - if there's a problem, create a new issue

--- a/.claude/skills/start-work-loop/SKILL.md
+++ b/.claude/skills/start-work-loop/SKILL.md
@@ -208,7 +208,11 @@ If the merge fails because the branch is out of date with master (Renovate may h
 After the merge succeeds:
 - The remote branch is auto-deleted (`deleteBranchOnMerge=true`)
 - Locally: `git checkout master && git pull --ff-only origin master && git branch -D <branch>`
-- The closing keyword in the PR body (`Closes #N`) auto-closes the issue → moves to Done
+- The closing keyword in the PR body (`Closes #N`) auto-closes the issue → moves to Done. **Verify** the issue landed in Done (`gh issue view <N> --json state,projectItems`). If it's still In Review (no closing keyword fired, or the project field didn't update), move it manually:
+  ```bash
+  gh issue close <N>
+  .claude/skills/start-work/scripts/set-issue-status.sh <N> done
+  ```
 - Add the issue to `completed_issues`
 - Continue to step 8
 


### PR DESCRIPTION
Closes #216

## Summary
- Update [.claude/rules/project-management.md](/.claude/rules/project-management.md): the post-merge rule now states that agents should move/close the linked issue to Done themselves when the PR's `Closes #N` keyword didn't fire (rather than leaving merged work in In Review).
- Update [.claude/skills/start-work-loop/SKILL.md](/.claude/skills/start-work-loop/SKILL.md): add an explicit "verify the issue landed in Done, otherwise close it and run `set-issue-status.sh <N> done`" step after a successful merge.

## Why
Older guidance had agents leave issues in In Review after merge. The current trunk-based workflow expects merged work to land in Done — either via the auto-close keyword or via an explicit agent action when the keyword didn't take effect.

## Out of scope
- The "Never move issues out of Done" rule is unchanged.
- All other status transitions (Backlog/Ready/In Progress) are unchanged.

## Test plan
- [ ] Read the diff of `.claude/rules/project-management.md` — Rules section reads cleanly and conveys "agents may move to Done on merge."
- [ ] Read the diff of `.claude/skills/start-work-loop/SKILL.md` — post-merge step now includes a verify + fallback close.