### PR TITLE
#219 Fix home screen stuck on loading indicator

### DIFF
--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
@@ -22,7 +22,6 @@ class HomeCompositor(
   private val recentlyAddedModel: RecentlyAddedModel,
   private val librariesModel: LibrariesModel,
 ) : ViceCompositor<HomeIntent, HomeViewState> {
-  private var isLoading by mutableStateOf(true)
   private var isRefreshing by mutableStateOf(false)
   private var error by mutableStateOf<HomeError?>(null)
 
@@ -44,7 +43,6 @@ class HomeCompositor(
 
     return HomeViewState(
       userName = userName,
-      isLoading = isLoading,
       error = error,
       isRefreshing = isRefreshing,
       continueWatchingState = continueWatchingState,
@@ -88,14 +86,11 @@ class HomeCompositor(
   }
 
   private suspend fun retryLoad() {
-    isLoading = true
     error = null
 
     val isValid = sessionManager.validateSession()
     if(!isValid) {
       error = HomeError.Network()
     }
-
-    isLoading = false
   }
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
@@ -1,7 +1,6 @@
 package com.eygraber.jellyfin.screens.home
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -81,7 +79,6 @@ internal fun HomeView(
           .padding(contentPadding),
       ) {
         when {
-          state.isLoading -> LoadingContent()
           state.error != null -> ErrorContent(
             error = state.error,
             onRetry = { onIntent(HomeIntent.RetryLoad) },
@@ -93,16 +90,6 @@ internal fun HomeView(
         }
       }
     }
-  }
-}
-
-@Composable
-private fun LoadingContent() {
-  Box(
-    modifier = Modifier.fillMaxSize(),
-    contentAlignment = Alignment.Center,
-  ) {
-    CircularProgressIndicator()
   }
 }
 
@@ -258,7 +245,7 @@ private fun LibrariesHomeSection(
 private fun HomeLoadingPreview() {
   JellyfinPreviewTheme {
     HomeView(
-      state = HomeViewState.Loading,
+      state = HomeViewState(),
       onIntent = {},
     )
   }
@@ -270,7 +257,6 @@ private fun HomeErrorPreview() {
   JellyfinPreviewTheme {
     HomeView(
       state = HomeViewState(
-        isLoading = false,
         error = HomeError.Network(),
       ),
       onIntent = {},
@@ -285,7 +271,6 @@ private fun HomeContentPreview() {
     HomeView(
       state = HomeViewState(
         userName = "TestUser",
-        isLoading = false,
       ),
       onIntent = {},
     )
@@ -299,7 +284,6 @@ private fun HomeContinueWatchingPreview() {
     HomeView(
       state = HomeViewState(
         userName = "TestUser",
-        isLoading = false,
         continueWatchingState = ContinueWatchingState.Loaded(
           items = listOf(
             ContinueWatchingItem(
@@ -353,7 +337,6 @@ private fun HomeContinueWatchingEmptyPreview() {
     HomeView(
       state = HomeViewState(
         userName = "TestUser",
-        isLoading = false,
         continueWatchingState = ContinueWatchingState.Empty,
       ),
       onIntent = {},

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeViewState.kt
@@ -5,18 +5,13 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class HomeViewState(
   val userName: String = "",
-  val isLoading: Boolean = true,
   val error: HomeError? = null,
   val isRefreshing: Boolean = false,
   val continueWatchingState: ContinueWatchingState = ContinueWatchingState.Loading,
   val nextUpState: NextUpState = NextUpState.Loading,
   val recentlyAddedState: RecentlyAddedState = RecentlyAddedState.Loading,
   val librariesState: LibrariesState = LibrariesState.Loading,
-) {
-  companion object {
-    val Loading = HomeViewState(isLoading = true)
-  }
-}
+)
 
 @Immutable
 sealed interface HomeError {


### PR DESCRIPTION
## Summary

- Removes the top-level `isLoading` flag from `HomeViewState`/`HomeCompositor` — it was initialized to `true` and never reset on initial load, so the home screen sat on the full-screen spinner indefinitely.
- Drops the `state.isLoading -> LoadingContent()` branch and the `LoadingContent` composable from `HomeView`. Each section already has its own `Loading` variant, which now drives any per-section loading UI.

## Test plan

- [ ] Launch the app and open the home screen — section layout paints immediately, no full-screen spinner gate.
- [ ] Sections show their own loading state until data arrives, then swap in.
- [ ] Pull-to-refresh still works.
- [ ] Retry flow still works (when an error is shown).

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)