### PR TITLE
#58 Add iOS video player using AVPlayer

### DIFF
--- a/services/player/impl/build.gradle.kts
+++ b/services/player/impl/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.eygraber.jellyfin.gradle.createCmpGroup
-
 plugins {
   alias(libs.plugins.conventionsAndroidKmpLibrary)
   alias(libs.plugins.conventionsComposeMultiplatform)
@@ -15,8 +13,6 @@ kotlin {
     project = project,
     androidNamespace = "com.eygraber.jellyfin.services.player.impl",
   )
-
-  createCmpGroup()
 
   sourceSets {
     androidMain.dependencies {

--- a/services/player/impl/src/iosMain/kotlin/com/eygraber/jellyfin/services/player/impl/IosVideoPlayerService.kt
+++ b/services/player/impl/src/iosMain/kotlin/com/eygraber/jellyfin/services/player/impl/IosVideoPlayerService.kt
@@ -1,0 +1,217 @@
+package com.eygraber.jellyfin.services.player.impl
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.viewinterop.UIKitViewController
+import com.eygraber.jellyfin.di.scopes.ScreenScope
+import com.eygraber.jellyfin.services.player.PlaybackState
+import com.eygraber.jellyfin.services.player.VideoPlayerService
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import platform.AVFoundation.AVPlayer
+import platform.AVFoundation.AVPlayerItem
+import platform.AVFoundation.AVPlayerItemDidPlayToEndTimeNotification
+import platform.AVFoundation.AVPlayerItemFailedToPlayToEndTimeErrorKey
+import platform.AVFoundation.AVPlayerItemFailedToPlayToEndTimeNotification
+import platform.AVFoundation.AVPlayerItemStatusFailed
+import platform.AVFoundation.AVPlayerStatusFailed
+import platform.AVFoundation.AVPlayerTimeControlStatusPlaying
+import platform.AVFoundation.AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate
+import platform.AVFoundation.addPeriodicTimeObserverForInterval
+import platform.AVFoundation.currentItem
+import platform.AVFoundation.currentTime
+import platform.AVFoundation.duration
+import platform.AVFoundation.pause
+import platform.AVFoundation.play
+import platform.AVFoundation.removeTimeObserver
+import platform.AVFoundation.replaceCurrentItemWithPlayerItem
+import platform.AVFoundation.seekToTime
+import platform.AVFoundation.timeControlStatus
+import platform.AVKit.AVPlayerViewController
+import platform.CoreMedia.CMTimeGetSeconds
+import platform.CoreMedia.CMTimeMakeWithSeconds
+import platform.Foundation.NSError
+import platform.Foundation.NSNotification
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSURL
+import platform.darwin.NSEC_PER_SEC
+
+/**
+ * iOS implementation of [VideoPlayerService] using AVPlayer.
+ *
+ * Renders video via [AVPlayerViewController] hosted in a [UIKitViewController] composable. State
+ * updates are driven by a periodic time observer plus notification observers for end-of-playback
+ * and item failures. Native controls are disabled because the screen layers its own controls
+ * overlay.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@SingleIn(ScreenScope::class)
+@ContributesBinding(ScreenScope::class)
+class IosVideoPlayerService : VideoPlayerService {
+  private val _playbackState = MutableStateFlow(PlaybackState.Idle)
+  override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
+
+  private var player: AVPlayer? = null
+  private var timeObserver: Any? = null
+  private var endObserver: Any? = null
+  private var failureObserver: Any? = null
+
+  override fun initialize(streamUrl: String, startPositionMs: Long) {
+    release()
+
+    val url = NSURL.URLWithString(streamUrl) ?: run {
+      _playbackState.value = PlaybackState(
+        hasError = true,
+        errorMessage = "Invalid stream URL",
+      )
+      return
+    }
+
+    val item = AVPlayerItem.playerItemWithURL(url)
+    val newPlayer = AVPlayer.playerWithPlayerItem(item)
+
+    if(startPositionMs > 0L) {
+      newPlayer.seekToTime(secondsToCmTime(startPositionMs.toDouble() / MS_PER_SECOND))
+    }
+
+    timeObserver = newPlayer.addPeriodicTimeObserverForInterval(
+      interval = secondsToCmTime(TIME_OBSERVER_INTERVAL_SECONDS),
+      queue = null,
+    ) { _ ->
+      updateState(newPlayer)
+    }
+
+    endObserver = NSNotificationCenter.defaultCenter.addObserverForName(
+      name = AVPlayerItemDidPlayToEndTimeNotification,
+      `object` = item,
+      queue = null,
+    ) { _: NSNotification? ->
+      _playbackState.value = _playbackState.value.copy(
+        isPlaying = false,
+        isBuffering = false,
+        isEnded = true,
+      )
+    }
+
+    failureObserver = NSNotificationCenter.defaultCenter.addObserverForName(
+      name = AVPlayerItemFailedToPlayToEndTimeNotification,
+      `object` = item,
+      queue = null,
+    ) { notification: NSNotification? ->
+      val error = notification?.userInfo?.get(AVPlayerItemFailedToPlayToEndTimeErrorKey) as? NSError
+      _playbackState.value = _playbackState.value.copy(
+        hasError = true,
+        errorMessage = error?.localizedDescription ?: "Playback failed",
+      )
+    }
+
+    player = newPlayer
+    newPlayer.play()
+    updateState(newPlayer)
+  }
+
+  override fun play() {
+    player?.play()
+  }
+
+  override fun pause() {
+    player?.pause()
+  }
+
+  override fun seekTo(positionMs: Long) {
+    player?.seekToTime(secondsToCmTime(positionMs.toDouble() / MS_PER_SECOND))
+  }
+
+  override fun release() {
+    player?.let { current ->
+      timeObserver?.let(current::removeTimeObserver)
+      current.pause()
+      current.replaceCurrentItemWithPlayerItem(null)
+    }
+    timeObserver = null
+    endObserver?.let { NSNotificationCenter.defaultCenter.removeObserver(it) }
+    failureObserver?.let { NSNotificationCenter.defaultCenter.removeObserver(it) }
+    endObserver = null
+    failureObserver = null
+    player = null
+    _playbackState.value = PlaybackState.Idle
+  }
+
+  @Composable
+  override fun VideoSurface(modifier: Modifier) {
+    val currentPlayer = player
+    if(currentPlayer == null) {
+      Box(modifier = modifier.fillMaxSize().background(Color.Black))
+      return
+    }
+
+    val controller = remember(currentPlayer) {
+      AVPlayerViewController().apply {
+        player = currentPlayer
+        showsPlaybackControls = false
+      }
+    }
+
+    UIKitViewController(
+      factory = { controller },
+      modifier = modifier,
+    )
+  }
+
+  private fun updateState(player: AVPlayer) {
+    val item = player.currentItem
+    val durationSeconds = item?.duration?.let { CMTimeGetSeconds(it) } ?: 0.0
+    val durationMs = secondsToMs(durationSeconds)
+    val currentMs = secondsToMs(CMTimeGetSeconds(player.currentTime()))
+
+    val timeControl = player.timeControlStatus
+    val isPlaying = timeControl == AVPlayerTimeControlStatusPlaying
+    val isBuffering = timeControl == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate
+
+    val hasError = player.status == AVPlayerStatusFailed || item?.status == AVPlayerItemStatusFailed
+    val errorMessage = if(hasError) {
+      player.error?.localizedDescription ?: item?.error?.localizedDescription ?: "Playback error"
+    }
+    else {
+      null
+    }
+
+    _playbackState.value = PlaybackState(
+      isPlaying = isPlaying,
+      isBuffering = isBuffering,
+      isEnded = _playbackState.value.isEnded,
+      hasError = hasError,
+      errorMessage = errorMessage,
+      currentPositionMs = currentMs,
+      durationMs = durationMs,
+      bufferedPositionMs = currentMs,
+    )
+  }
+
+  private fun secondsToMs(seconds: Double): Long =
+    if(seconds.isFinite() && seconds > 0.0) {
+      (seconds * MS_PER_SECOND).toLong()
+    }
+    else {
+      0L
+    }
+
+  private fun secondsToCmTime(seconds: Double) = CMTimeMakeWithSeconds(
+    seconds = seconds,
+    preferredTimescale = NSEC_PER_SEC.toInt(),
+  )
+
+  companion object {
+    private const val MS_PER_SECOND = 1_000.0
+    private const val TIME_OBSERVER_INTERVAL_SECONDS = 0.5
+  }
+}

--- a/services/player/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/player/impl/JvmVideoPlayerService.kt
+++ b/services/player/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/player/impl/JvmVideoPlayerService.kt
@@ -1,0 +1,52 @@
+package com.eygraber.jellyfin.services.player.impl
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.eygraber.jellyfin.di.scopes.ScreenScope
+import com.eygraber.jellyfin.services.player.PlaybackState
+import com.eygraber.jellyfin.services.player.VideoPlayerService
+import dev.zacsweers.metro.ContributesBinding
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Placeholder Desktop (JVM) implementation. Replaced with a real player in #59.
+ */
+@ContributesBinding(ScreenScope::class)
+class JvmVideoPlayerService : VideoPlayerService {
+  private val _playbackState = MutableStateFlow(
+    PlaybackState(
+      hasError = true,
+      errorMessage = "Video playback is not supported on Desktop yet",
+    ),
+  )
+  override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
+
+  override fun initialize(streamUrl: String, startPositionMs: Long) = Unit
+  override fun play() = Unit
+  override fun pause() = Unit
+  override fun seekTo(positionMs: Long) = Unit
+  override fun release() = Unit
+
+  @Composable
+  override fun VideoSurface(modifier: Modifier) {
+    Box(
+      modifier = modifier.fillMaxSize().background(Color.Black),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text(
+        text = "Video playback not yet supported on Desktop",
+        color = Color.White,
+        style = MaterialTheme.typography.bodyMedium,
+      )
+    }
+  }
+}

--- a/services/player/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/player/impl/WasmJsVideoPlayerService.kt
+++ b/services/player/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/player/impl/WasmJsVideoPlayerService.kt
@@ -18,41 +18,23 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Stub [VideoPlayerService] used on iOS, Desktop (JVM), and Web (WasmJs).
- *
- * Each platform will get its own native implementation in a follow-up issue
- * (AVPlayer for iOS, VLC/JavaFX for Desktop, HTML5 Video for Web). Until then,
- * this stub reports an error state so the UI can surface "not supported" messaging.
+ * Placeholder Web (WasmJs) implementation. Replaced with a real player in #59.
  */
 @ContributesBinding(ScreenScope::class)
-class CmpVideoPlayerService : VideoPlayerService {
+class WasmJsVideoPlayerService : VideoPlayerService {
   private val _playbackState = MutableStateFlow(
     PlaybackState(
       hasError = true,
-      errorMessage = "Video playback is not supported on this platform yet",
+      errorMessage = "Video playback is not supported on Web yet",
     ),
   )
   override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
-  override fun initialize(streamUrl: String, startPositionMs: Long) {
-    // No-op
-  }
-
-  override fun play() {
-    // No-op
-  }
-
-  override fun pause() {
-    // No-op
-  }
-
-  override fun seekTo(positionMs: Long) {
-    // No-op
-  }
-
-  override fun release() {
-    // No-op
-  }
+  override fun initialize(streamUrl: String, startPositionMs: Long) = Unit
+  override fun play() = Unit
+  override fun pause() = Unit
+  override fun seekTo(positionMs: Long) = Unit
+  override fun release() = Unit
 
   @Composable
   override fun VideoSurface(modifier: Modifier) {
@@ -61,7 +43,7 @@ class CmpVideoPlayerService : VideoPlayerService {
       contentAlignment = Alignment.Center,
     ) {
       Text(
-        text = "Video playback not yet supported on this platform",
+        text = "Video playback not yet supported on Web",
         color = Color.White,
         style = MaterialTheme.typography.bodyMedium,
       )


### PR DESCRIPTION
## Summary
- iOS implementation of `VideoPlayerService` using `AVPlayer` rendered via `AVPlayerViewController` inside a `UIKitViewController` composable
- Periodic time observer drives `PlaybackState`; `NSNotificationCenter` observers handle end-of-play and item failures
- Native controls disabled — the screen layers its own controls overlay
- Restructure `services/player/impl` source sets: drops the shared `cmpMain` stub in favor of platform-specific `iosMain`, `jvmMain`, `wasmJsMain` impls. JVM and WasmJs are placeholders until #59.

Closes #58

## Test plan
- [ ] iOS: launch a video via `VideoPlayerKey` and confirm AVPlayer renders the stream, play/pause, and seek work
- [ ] iOS: confirm playback state transitions (loading → playing → paused) reach the controls overlay
- [ ] iOS: navigating back releases the player (no leaked time observers / KVO)
- [ ] Desktop / Web: confirm the placeholder error message renders without breaking the build

## Notes
- Cross-compile to iOS is not supported on Linux hosts, so the iOS implementation was not verified locally and CI does not run iOS jobs. It needs a macOS build to confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)