### PR TITLE
#59 Add Desktop and Web video player implementations

### DIFF
--- a/apps/shared/build.gradle.kts
+++ b/apps/shared/build.gradle.kts
@@ -126,4 +126,10 @@ licensee {
   allowUrl("https://opensource.org/license/mit")
 
   allowDependency(libs.jellyfinLint)
+
+  // VLCJ is GPL-3.0; required for Desktop video playback (see #59).
+  allowDependency(libs.vlcj)
+
+  // vlcj-natives ships a non-standard GPL-3.0 license URL; pulled in transitively by vlcj.
+  allowUrl("http://www.gnu.org/licenses/gpl-3.0.html")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,8 @@ jvmTarget = "17"
 
 khronicle = "0.5.2"
 
+vlcj = "4.11.0"
+
 kotest = "6.1.11"
 
 kotlin = "2.3.21"
@@ -178,6 +180,8 @@ kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 khronicle = { module = "com.juul.khronicle:khronicle-core", version.ref = "khronicle" }
+
+vlcj = { module = "uk.co.caprica:vlcj", version.ref = "vlcj" }
 
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/services/player/impl/build.gradle.kts
+++ b/services/player/impl/build.gradle.kts
@@ -20,6 +20,10 @@ kotlin {
       implementation(libs.androidx.media3.ui.compose)
     }
 
+    jvmMain.dependencies {
+      implementation(libs.vlcj)
+    }
+
     commonMain.dependencies {
       api(projects.di)
       api(projects.services.player.public)

--- a/services/player/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/player/impl/JvmVideoPlayerService.kt
+++ b/services/player/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/player/impl/JvmVideoPlayerService.kt
@@ -8,45 +8,186 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.graphics.Color
 import com.eygraber.jellyfin.di.scopes.ScreenScope
 import com.eygraber.jellyfin.services.player.PlaybackState
 import com.eygraber.jellyfin.services.player.VideoPlayerService
 import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import uk.co.caprica.vlcj.factory.discovery.NativeDiscovery
+import uk.co.caprica.vlcj.player.base.MediaPlayer
+import uk.co.caprica.vlcj.player.base.MediaPlayerEventAdapter
+import uk.co.caprica.vlcj.player.component.EmbeddedMediaPlayerComponent
+import javax.swing.SwingUtilities
 
 /**
- * Placeholder Desktop (JVM) implementation. Replaced with a real player in #59.
+ * Desktop (JVM) implementation of [VideoPlayerService] using vlcj.
+ *
+ * Wraps [EmbeddedMediaPlayerComponent] (a Swing component) and renders it inside Compose via
+ * [SwingPanel]. Requires a libvlc installation reachable via [NativeDiscovery]; if libvlc cannot
+ * be found we fall back to an error state.
+ *
+ * Component lifecycle is owned by this service: [initialize] creates a fresh player on the EDT,
+ * [release] tears it down. UI rendering simply binds the existing component to a [SwingPanel].
  */
+@SingleIn(ScreenScope::class)
 @ContributesBinding(ScreenScope::class)
 class JvmVideoPlayerService : VideoPlayerService {
-  private val _playbackState = MutableStateFlow(
-    PlaybackState(
-      hasError = true,
-      errorMessage = "Video playback is not supported on Desktop yet",
-    ),
-  )
+  private val _playbackState = MutableStateFlow(PlaybackState.Idle)
   override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
-  override fun initialize(streamUrl: String, startPositionMs: Long) = Unit
-  override fun play() = Unit
-  override fun pause() = Unit
-  override fun seekTo(positionMs: Long) = Unit
-  override fun release() = Unit
+  private var component: EmbeddedMediaPlayerComponent? = null
+
+  override fun initialize(streamUrl: String, startPositionMs: Long) {
+    release()
+
+    val newComponent = createComponentOnEdt() ?: run {
+      _playbackState.value = PlaybackState(
+        hasError = true,
+        errorMessage = "VLC libraries not found. Install VLC to enable Desktop playback.",
+      )
+      return
+    }
+
+    component = newComponent
+
+    val player = newComponent.mediaPlayer()
+    player.events().addMediaPlayerEventListener(VlcEventListener())
+    player.media().play(streamUrl)
+    if(startPositionMs > 0L) {
+      player.controls().setTime(startPositionMs)
+    }
+  }
+
+  override fun play() {
+    component?.mediaPlayer()?.controls()?.play()
+  }
+
+  override fun pause() {
+    component?.mediaPlayer()?.controls()?.pause()
+  }
+
+  override fun seekTo(positionMs: Long) {
+    component?.mediaPlayer()?.controls()?.setTime(positionMs)
+  }
+
+  override fun release() {
+    val current = component ?: return
+    component = null
+    SwingUtilities.invokeLater { current.release() }
+    _playbackState.value = PlaybackState.Idle
+  }
 
   @Composable
   override fun VideoSurface(modifier: Modifier) {
-    Box(
-      modifier = modifier.fillMaxSize().background(Color.Black),
-      contentAlignment = Alignment.Center,
-    ) {
-      Text(
-        text = "Video playback not yet supported on Desktop",
-        color = Color.White,
-        style = MaterialTheme.typography.bodyMedium,
+    val current = component
+    if(current == null) {
+      Box(
+        modifier = modifier.fillMaxSize().background(Color.Black),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = "Player not initialized",
+          color = Color.White,
+          style = MaterialTheme.typography.bodyMedium,
+        )
+      }
+      return
+    }
+
+    SwingPanel(
+      factory = { current },
+      modifier = modifier,
+      background = Color.Black,
+    )
+  }
+
+  private fun createComponentOnEdt(): EmbeddedMediaPlayerComponent? {
+    if(!isNativeDiscoverySuccessful) return null
+
+    var component: EmbeddedMediaPlayerComponent? = null
+    val task = Runnable {
+      component = runCatching { EmbeddedMediaPlayerComponent() }.getOrNull()
+    }
+    if(SwingUtilities.isEventDispatchThread()) {
+      task.run()
+    }
+    else {
+      SwingUtilities.invokeAndWait(task)
+    }
+    return component
+  }
+
+  private inner class VlcEventListener : MediaPlayerEventAdapter() {
+    override fun playing(mediaPlayer: MediaPlayer) {
+      pushState(mediaPlayer, isPlaying = true, isBuffering = false)
+    }
+
+    override fun paused(mediaPlayer: MediaPlayer) {
+      pushState(mediaPlayer, isPlaying = false, isBuffering = false)
+    }
+
+    override fun stopped(mediaPlayer: MediaPlayer) {
+      pushState(mediaPlayer, isPlaying = false, isBuffering = false)
+    }
+
+    override fun finished(mediaPlayer: MediaPlayer) {
+      pushState(
+        mediaPlayer = mediaPlayer,
+        isPlaying = false,
+        isBuffering = false,
+        isEnded = true,
       )
     }
+
+    override fun buffering(mediaPlayer: MediaPlayer, newCache: Float) {
+      pushState(
+        mediaPlayer = mediaPlayer,
+        isPlaying = mediaPlayer.status().isPlaying,
+        isBuffering = newCache < FULL_BUFFER_PERCENT,
+      )
+    }
+
+    override fun timeChanged(mediaPlayer: MediaPlayer, newTime: Long) {
+      pushState(
+        mediaPlayer = mediaPlayer,
+        isPlaying = mediaPlayer.status().isPlaying,
+        isBuffering = false,
+        currentMs = newTime,
+      )
+    }
+
+    override fun error(mediaPlayer: MediaPlayer) {
+      _playbackState.value = _playbackState.value.copy(
+        hasError = true,
+        errorMessage = "Playback error",
+      )
+    }
+
+    private fun pushState(
+      mediaPlayer: MediaPlayer,
+      isPlaying: Boolean,
+      isBuffering: Boolean,
+      isEnded: Boolean = _playbackState.value.isEnded,
+      currentMs: Long = mediaPlayer.status().time(),
+    ) {
+      _playbackState.value = PlaybackState(
+        isPlaying = isPlaying,
+        isBuffering = isBuffering,
+        isEnded = isEnded,
+        currentPositionMs = currentMs.coerceAtLeast(0L),
+        durationMs = mediaPlayer.status().length().coerceAtLeast(0L),
+        bufferedPositionMs = currentMs.coerceAtLeast(0L),
+      )
+    }
+  }
+
+  companion object {
+    private val isNativeDiscoverySuccessful: Boolean = NativeDiscovery().discover()
+    private const val FULL_BUFFER_PERCENT = 100f
   }
 }

--- a/services/player/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/player/impl/WasmJsVideoPlayerService.kt
+++ b/services/player/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/player/impl/WasmJsVideoPlayerService.kt
@@ -3,50 +3,120 @@ package com.eygraber.jellyfin.services.player.impl
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.eygraber.jellyfin.di.scopes.ScreenScope
 import com.eygraber.jellyfin.services.player.PlaybackState
 import com.eygraber.jellyfin.services.player.VideoPlayerService
 import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.browser.document
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.w3c.dom.HTMLVideoElement
+import kotlin.js.ExperimentalWasmJsInterop
 
 /**
- * Placeholder Web (WasmJs) implementation. Replaced with a real player in #59.
+ * Web (WasmJs) implementation of [VideoPlayerService].
+ *
+ * Creates an `<video>` element overlay positioned fullscreen above the Compose canvas. Uses the
+ * browser's native HTML5 controls so the user can play/pause/seek; the Compose controls overlay
+ * is hidden behind the video. To exit playback, the user navigates back via the browser or by
+ * triggering Compose's NavigateBack intent (which calls [release] and removes the element).
  */
+@OptIn(ExperimentalWasmJsInterop::class)
+@SingleIn(ScreenScope::class)
 @ContributesBinding(ScreenScope::class)
 class WasmJsVideoPlayerService : VideoPlayerService {
-  private val _playbackState = MutableStateFlow(
-    PlaybackState(
-      hasError = true,
-      errorMessage = "Video playback is not supported on Web yet",
-    ),
-  )
+  private val _playbackState = MutableStateFlow(PlaybackState.Idle)
   override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
-  override fun initialize(streamUrl: String, startPositionMs: Long) = Unit
-  override fun play() = Unit
-  override fun pause() = Unit
-  override fun seekTo(positionMs: Long) = Unit
-  override fun release() = Unit
+  private var videoElement: HTMLVideoElement? = null
+
+  override fun initialize(streamUrl: String, startPositionMs: Long) {
+    release()
+
+    val video = (document.createElement("video") as HTMLVideoElement).apply {
+      src = streamUrl
+      controls = true
+      autoplay = true
+      style.cssText = OVERLAY_STYLE
+      if(startPositionMs > 0L) {
+        currentTime = startPositionMs.toDouble() / MS_PER_SECOND
+      }
+    }
+
+    video.addEventListener("playing") { syncStateFromElement(isPlaying = true) }
+    video.addEventListener("pause") { syncStateFromElement(isPlaying = false) }
+    video.addEventListener("waiting") { syncStateFromElement(isBuffering = true) }
+    video.addEventListener("canplay") { syncStateFromElement(isBuffering = false) }
+    video.addEventListener("ended") { syncStateFromElement(isPlaying = false, isEnded = true) }
+    video.addEventListener("timeupdate") { syncStateFromElement() }
+    video.addEventListener("error") {
+      _playbackState.value = _playbackState.value.copy(
+        hasError = true,
+        errorMessage = "Playback error",
+      )
+    }
+
+    document.body?.appendChild(video)
+    videoElement = video
+  }
+
+  override fun play() {
+    videoElement?.play()
+  }
+
+  override fun pause() {
+    videoElement?.pause()
+  }
+
+  override fun seekTo(positionMs: Long) {
+    videoElement?.currentTime = positionMs.toDouble() / MS_PER_SECOND
+  }
+
+  override fun release() {
+    val element = videoElement ?: return
+    videoElement = null
+    element.pause()
+    element.removeAttribute("src")
+    element.parentNode?.removeChild(element)
+    _playbackState.value = PlaybackState.Idle
+  }
 
   @Composable
   override fun VideoSurface(modifier: Modifier) {
-    Box(
-      modifier = modifier.fillMaxSize().background(Color.Black),
-      contentAlignment = Alignment.Center,
-    ) {
-      Text(
-        text = "Video playback not yet supported on Web",
-        color = Color.White,
-        style = MaterialTheme.typography.bodyMedium,
-      )
-    }
+    Box(modifier = modifier.fillMaxSize().background(Color.Black))
+  }
+
+  private fun syncStateFromElement(
+    isPlaying: Boolean? = null,
+    isBuffering: Boolean? = null,
+    isEnded: Boolean = false,
+  ) {
+    val element = videoElement ?: return
+    val current = _playbackState.value
+    val durationMs = element.duration
+      .takeIf { !it.isNaN() && !it.isInfinite() && it > 0.0 }
+      ?.let { (it * MS_PER_SECOND).toLong() }
+      ?: 0L
+    val currentMs = (element.currentTime * MS_PER_SECOND).toLong().coerceAtLeast(0L)
+
+    _playbackState.value = current.copy(
+      isPlaying = isPlaying ?: !element.paused,
+      isBuffering = isBuffering ?: false,
+      isEnded = isEnded || current.isEnded && isPlaying != true,
+      currentPositionMs = currentMs,
+      durationMs = durationMs,
+      bufferedPositionMs = currentMs,
+    )
+  }
+
+  companion object {
+    private const val MS_PER_SECOND = 1_000.0
+    private const val OVERLAY_STYLE =
+      "position:fixed;top:0;left:0;width:100vw;height:100vh;background:black;z-index:9999;"
   }
 }


### PR DESCRIPTION
## Summary
- **Desktop (JVM)**: vlcj-backed `EmbeddedMediaPlayerComponent` rendered through Compose's `SwingPanel`. The component is created on the EDT; player operations (play/pause/seek) are forwarded directly. Falls back to an explanatory error state when libvlc is not installed on the host machine.
- **Web (WasmJs)**: HTML5 `<video>` element appended to the document body as a fullscreen overlay (z-index 9999). Uses the browser's native HTML5 controls; element events drive `PlaybackState`. The element is removed from the DOM on `release()`, including via the screen's `DisposableEffect`.
- vlcj is GPL-3.0; added a scoped `allowDependency(libs.vlcj)` plus an `allowUrl` for vlcj-natives' non-standard license URL in licensee config.

Closes #59

## Test plan
- [ ] Desktop: with VLC installed, launch a video via `VideoPlayerKey` and confirm playback, play/pause, seek, and back-navigation cleanup
- [ ] Desktop: without VLC installed, confirm the error fallback message renders cleanly
- [ ] Web: launch a video and confirm the HTML5 overlay appears, native controls work, and navigating back removes the element
- [ ] License check: `./gradlew :apps:shared:licenseeJvm` passes

## Notes
- The Compose controls overlay for VideoPlayer is hidden behind the HTML5 element on Web by design, since Compose Web's canvas does not compose cleanly with arbitrary DOM elements. Future work could overlay a small DOM "back" affordance rather than relying on browser back.
- vlcj 4.x distributes the player API and `vlcj-natives` separately; only the natives jar carries an SPDX-resolvable license entry, so the parent `vlcj` allow line is reported as "unused" but is kept for documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)