### PR TITLE
#224 Wire detail Play buttons to launch the video player

### DIFF
--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
@@ -39,6 +39,7 @@ import com.eygraber.jellyfin.screens.tvshow.detail.TvShowDetailNavigator
 import com.eygraber.jellyfin.screens.tvshow.episodes.TvShowEpisodesKey
 import com.eygraber.jellyfin.screens.tvshow.episodes.TvShowEpisodesNavigator
 import com.eygraber.jellyfin.screens.tvshow.seasons.TvShowSeasonsNavigator
+import com.eygraber.jellyfin.screens.video.player.VideoPlayerKey
 import com.eygraber.jellyfin.screens.video.player.VideoPlayerNavigator
 import com.eygraber.jellyfin.screens.welcome.WelcomeKey
 import com.eygraber.jellyfin.screens.welcome.WelcomeNavigator
@@ -140,6 +141,9 @@ internal object JellyfinNavigators {
     onNavigateToSimilarItem = { itemId ->
       backStack.add(MovieDetailKey(movieId = itemId))
     },
+    onNavigateToPlayer = { itemId, itemName ->
+      backStack.add(VideoPlayerKey(itemId = itemId, itemName = itemName))
+    },
   )
 
   fun moviesLibrary(
@@ -191,6 +195,9 @@ internal object JellyfinNavigators {
     backStack: NavBackStack<NavKey>,
   ) = EpisodeDetailNavigator(
     onNavigateBack = { backStack.removeLastOrNull() },
+    onNavigateToPlayer = { itemId, itemName ->
+      backStack.add(VideoPlayerKey(itemId = itemId, itemName = itemName))
+    },
   )
 
   fun musicLibrary(

--- a/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailCompositor.kt
+++ b/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailCompositor.kt
@@ -32,6 +32,8 @@ class EpisodeDetailCompositor(
   override suspend fun onIntent(intent: EpisodeDetailIntent) {
     when(intent) {
       EpisodeDetailIntent.RetryLoad -> episodeModel.loadEpisode(key.episodeId)
+      is EpisodeDetailIntent.PlayEpisode ->
+        navigator.navigateToPlayer(itemId = intent.itemId, itemName = intent.itemName)
       EpisodeDetailIntent.NavigateBack -> navigator.navigateBack()
     }
   }

--- a/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailIntent.kt
+++ b/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailIntent.kt
@@ -2,5 +2,6 @@ package com.eygraber.jellyfin.screens.episode.detail
 
 sealed interface EpisodeDetailIntent {
   data object RetryLoad : EpisodeDetailIntent
+  data class PlayEpisode(val itemId: String, val itemName: String) : EpisodeDetailIntent
   data object NavigateBack : EpisodeDetailIntent
 }

--- a/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailNavigator.kt
+++ b/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailNavigator.kt
@@ -2,8 +2,13 @@ package com.eygraber.jellyfin.screens.episode.detail
 
 class EpisodeDetailNavigator(
   private val onNavigateBack: () -> Unit,
+  private val onNavigateToPlayer: (itemId: String, itemName: String?) -> Unit,
 ) {
   fun navigateBack() {
     onNavigateBack()
+  }
+
+  fun navigateToPlayer(itemId: String, itemName: String?) {
+    onNavigateToPlayer(itemId, itemName)
   }
 }

--- a/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailView.kt
+++ b/screens/episode-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/episode/detail/EpisodeDetailView.kt
@@ -80,7 +80,12 @@ internal fun EpisodeDetailView(
             error = state.error,
             onRetry = { onIntent(EpisodeDetailIntent.RetryLoad) },
           )
-          state.episode != null -> EpisodeContent(episode = state.episode)
+          state.episode != null -> EpisodeContent(
+            episode = state.episode,
+            onPlay = {
+              onIntent(EpisodeDetailIntent.PlayEpisode(itemId = state.episode.id, itemName = state.episode.name))
+            },
+          )
         }
       }
     }
@@ -90,6 +95,7 @@ internal fun EpisodeDetailView(
 @Composable
 private fun EpisodeContent(
   episode: EpisodeDetail,
+  onPlay: () -> Unit,
 ) {
   Column(
     modifier = Modifier
@@ -126,7 +132,7 @@ private fun EpisodeContent(
       Spacer(modifier = Modifier.height(16.dp))
 
       Button(
-        onClick = { },
+        onClick = onPlay,
       ) {
         Icon(
           imageVector = JellyfinIcons.PlayArrow,

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailCompositor.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailCompositor.kt
@@ -36,6 +36,8 @@ class MovieDetailCompositor(
     when(intent) {
       MovieDetailIntent.RetryLoad -> movieModel.loadMovie(key.movieId)
       is MovieDetailIntent.SelectSimilarItem -> navigator.navigateToSimilarItem(intent.itemId)
+      is MovieDetailIntent.PlayMovie ->
+        navigator.navigateToPlayer(itemId = intent.itemId, itemName = intent.itemName)
       MovieDetailIntent.NavigateBack -> navigator.navigateBack()
     }
   }

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailIntent.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailIntent.kt
@@ -3,5 +3,6 @@ package com.eygraber.jellyfin.screens.movie.detail
 sealed interface MovieDetailIntent {
   data object RetryLoad : MovieDetailIntent
   data class SelectSimilarItem(val itemId: String) : MovieDetailIntent
+  data class PlayMovie(val itemId: String, val itemName: String) : MovieDetailIntent
   data object NavigateBack : MovieDetailIntent
 }

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailNavigator.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailNavigator.kt
@@ -3,6 +3,7 @@ package com.eygraber.jellyfin.screens.movie.detail
 class MovieDetailNavigator(
   private val onNavigateBack: () -> Unit,
   private val onNavigateToSimilarItem: (itemId: String) -> Unit,
+  private val onNavigateToPlayer: (itemId: String, itemName: String?) -> Unit,
 ) {
   fun navigateBack() {
     onNavigateBack()
@@ -10,5 +11,9 @@ class MovieDetailNavigator(
 
   fun navigateToSimilarItem(itemId: String) {
     onNavigateToSimilarItem(itemId)
+  }
+
+  fun navigateToPlayer(itemId: String, itemName: String?) {
+    onNavigateToPlayer(itemId, itemName)
   }
 }

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailView.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailView.kt
@@ -104,6 +104,9 @@ internal fun MovieDetailView(
             onSimilarItemClick = { itemId ->
               onIntent(MovieDetailIntent.SelectSimilarItem(itemId))
             },
+            onPlay = {
+              onIntent(MovieDetailIntent.PlayMovie(itemId = state.movie.id, itemName = state.movie.name))
+            },
           )
         }
       }
@@ -118,6 +121,7 @@ private fun MovieContent(
   crew: List<CrewMember>,
   similarItems: List<SimilarItem>,
   onSimilarItemClick: (itemId: String) -> Unit,
+  onPlay: () -> Unit,
 ) {
   Column(
     modifier = Modifier
@@ -144,7 +148,7 @@ private fun MovieContent(
       Spacer(modifier = Modifier.height(16.dp))
 
       Button(
-        onClick = { },
+        onClick = onPlay,
       ) {
         Icon(
           imageVector = JellyfinIcons.PlayArrow,


### PR DESCRIPTION
## Summary
- Adds `PlayMovie(itemId, itemName)` to `MovieDetailIntent` and `PlayEpisode(itemId, itemName)` to `EpisodeDetailIntent`
- Extends `MovieDetailNavigator` and `EpisodeDetailNavigator` with `navigateToPlayer(itemId, itemName)`
- Wires the new callback in `JellyfinNavigators` so the navigator pushes a `VideoPlayerKey` onto the back stack
- Replaces the empty `onClick = { }` stubs on the Play buttons in both detail screens with `onIntent(...)` calls

Closes #224

## Test plan
- [ ] On a movie detail screen, tap Play and confirm navigation lands on the VideoPlayer screen with the movie title in the top bar
- [ ] Same for an episode detail screen
- [ ] Back from the player returns to the detail screen and releases the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)