### PR TITLE
#234 Enable compose.interop.blending so Desktop controls overlay shows

### DIFF
--- a/apps/desktop/src/main/kotlin/com/eygraber/jellyfin/app/JellyfinDesktopApp.kt
+++ b/apps/desktop/src/main/kotlin/com/eygraber/jellyfin/app/JellyfinDesktopApp.kt
@@ -17,6 +17,11 @@ import dev.zacsweers.metro.createGraphFactory
 import java.awt.Dimension
 
 fun main() {
+  // Allow Compose UI (e.g. the video player controls overlay) to render on top of SwingPanel
+  // interop content. Without this flag the embedded Swing video surface paints above any
+  // Compose layers, hiding the controls overlay.
+  System.setProperty("compose.interop.blending", "true")
+
   val appGraph = createGraphFactory<JellyfinDesktopAppGraph.Factory>().create()
   appGraph.initializer.initialize()
 


### PR DESCRIPTION
## Summary
Compose Multiplatform's `SwingPanel` renders interop (Swing) content above the Compose layer by default, so the video player's Compose controls overlay (play/pause, seek bar, back button) was hidden by the embedded vlcj video surface even after switching to the lightweight `CallbackMediaPlayerComponent`.

Setting the system property `compose.interop.blending=true` switches Compose Desktop to a render path that lets Compose UI composite on top of the interop region. Set it before the application graph is created so it takes effect for the whole window.

Stacked on **#235** (audio downmix) → **#232** (CallbackMediaPlayerComponent) → **#228** (displayable polling).

Closes #234

## Test plan
- [ ] Desktop: launch a video and confirm play/pause, seek bar, time labels, and back button are all visible while the video is playing
- [ ] Desktop: clicking on the controls still toggles them (so the overlay is interactive, not just rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)