### PR TITLE
Opt in to ExperimentalWasmJsInterop for currentTimeMillis on WasmJs

### DIFF
--- a/data/auth/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/data/auth/impl/CurrentTimeMillis.wasmJs.kt
+++ b/data/auth/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/data/auth/impl/CurrentTimeMillis.wasmJs.kt
@@ -1,5 +1,6 @@
 package com.eygraber.jellyfin.data.auth.impl
 
+@OptIn(ExperimentalWasmJsInterop::class)
 private fun dateNow(): Double = js("Date.now()")
 
 internal actual fun currentTimeMillis(): Long = dateNow().toLong()

--- a/data/search-history/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/data/search/history/impl/CurrentTimeMillis.wasmJs.kt
+++ b/data/search-history/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/data/search/history/impl/CurrentTimeMillis.wasmJs.kt
@@ -1,5 +1,6 @@
 package com.eygraber.jellyfin.data.search.history.impl
 
+@OptIn(ExperimentalWasmJsInterop::class)
 private fun dateNow(): Double = js("Date.now()")
 
 internal actual fun currentTimeMillis(): Long = dateNow().toLong()

--- a/domain/server/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/domain/server/impl/CurrentTimeMillis.wasmJs.kt
+++ b/domain/server/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/domain/server/impl/CurrentTimeMillis.wasmJs.kt
@@ -1,3 +1,6 @@
 package com.eygraber.jellyfin.domain.server.impl
 
-internal actual fun currentTimeMillis(): Long = js("Date.now()").toLong()
+internal actual fun currentTimeMillis() = jsDateNow().toLong()
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun jsDateNow(): Double = js("Date.now()")


### PR DESCRIPTION
## Summary
Recent Kotlin/Wasm requires `js("...")` interop to be opted into via `@kotlin.js.ExperimentalWasmJsInterop`. Three modules each ship their own `currentTimeMillis()` actual using `js("Date.now()")` and were failing to compile WasmJs:

- `data/auth/impl/.../CurrentTimeMillis.wasmJs.kt`
- `data/search-history/impl/.../CurrentTimeMillis.wasmJs.kt`
- `domain/server/impl/.../CurrentTimeMillis.wasmJs.kt`

This adds `@OptIn(ExperimentalWasmJsInterop::class)` on the JS-shim function in each. The `domain/server/impl` copy also gets lifted into a named private helper (`jsDateNow`) for consistency with the other two.

The duplication itself is tracked separately in **#244** — this PR just unblocks the WasmJs build.

## Test plan
- [x] `./gradlew :data:auth:impl:compileKotlinWasmJs :data:search-history:impl:compileKotlinWasmJs :domain:server:impl:compileKotlinWasmJs` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)