### PR TITLE
#246 Drop redundant @Inject from @ContributesBinding database providers

### DIFF
--- a/services/database/impl/src/androidMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.android.kt
+++ b/services/database/impl/src/androidMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.android.kt
@@ -13,10 +13,8 @@ import com.eygraber.sqldelight.androidx.driver.FileProvider
 import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 
-@Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 internal class AndroidJellyfinDatabaseProvider(

--- a/services/database/impl/src/iosMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.ios.kt
+++ b/services/database/impl/src/iosMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.ios.kt
@@ -10,13 +10,11 @@ import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDriver
 import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSUserDomainMask
 
-@Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 internal class IosJellyfinDatabaseProvider(

--- a/services/database/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.jvm.kt
+++ b/services/database/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.jvm.kt
@@ -11,11 +11,9 @@ import com.eygraber.sqldelight.androidx.driver.File
 import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import java.io.File
 
-@Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 internal class JvmJellyfinDatabaseProvider(

--- a/services/database/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.wasmJs.kt
+++ b/services/database/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.wasmJs.kt
@@ -4,7 +4,6 @@ import app.cash.sqldelight.db.SqlDriver
 import com.eygraber.jellyfin.services.database.JellyfinDatabaseProvider
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 
 /**
@@ -14,7 +13,6 @@ import dev.zacsweers.metro.SingleIn
  * generated API for all platforms. Full WasmJs support will be added in a future issue
  * using the async web worker driver.
  */
-@Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 internal class WasmJsJellyfinDatabaseProvider : JellyfinDatabaseProvider {


### PR DESCRIPTION
## Summary

- `@ContributesBinding` already makes a class injectable in Metro, so layering `@Inject` on top of it is redundant — and the konsist rule `MetroAnnotationRestrictionsTest.ContributesBinding classes should not have Inject annotation` fires on classes that carry both.
- The four `*JellyfinDatabaseProvider` classes added in #229 / PR #230 were tripping that rule, leaving `./konsist:test` red on `master` and blocking the pre-push hook.
- Removed `@Inject` (and its import) from the Android, JVM, iOS, and WasmJs provider classes. Constructor injection of `Context`, `DatabaseConfig`, etc. continues to work because Metro infers it from `@ContributesBinding`.

## Test plan

- [x] `./gradlew :konsist:test` — all 4 previously-failing dynamic tests pass
- [x] `./gradlew :services:database:impl:compileDebugKotlinAndroid :services:database:impl:compileKotlinJvm :services:database:impl:compileKotlinIosSimulatorArm64 :services:database:impl:compileKotlinWasmJs` — all four targets compile
- [x] `./check` — full PR check suite passes locally

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)