### PR TITLE
#240 Apply safe-drawing insets to Android video player controls overlay

### DIFF
--- a/screens/video-player/src/commonMain/kotlin/com/eygraber/jellyfin/screens/video/player/VideoPlayerView.kt
+++ b/screens/video-player/src/commonMain/kotlin/com/eygraber/jellyfin/screens/video/player/VideoPlayerView.kt
@@ -11,10 +11,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -165,8 +168,9 @@ private fun PlayerControlsOverlay(
     Row(
       modifier = Modifier
         .fillMaxWidth()
-        .padding(16.dp)
-        .align(Alignment.TopStart),
+        .align(Alignment.TopStart)
+        .windowInsetsPadding(WindowInsets.safeDrawing)
+        .padding(16.dp),
       verticalAlignment = Alignment.CenterVertically,
     ) {
       IconButton(onClick = { onIntent(VideoPlayerIntent.NavigateBack) }) {
@@ -212,8 +216,9 @@ private fun PlayerControlsOverlay(
     Column(
       modifier = Modifier
         .fillMaxWidth()
-        .padding(16.dp)
-        .align(Alignment.BottomStart),
+        .align(Alignment.BottomStart)
+        .windowInsetsPadding(WindowInsets.safeDrawing)
+        .padding(16.dp),
     ) {
       // Seek bar
       Slider(


### PR DESCRIPTION
## Summary

- The video player's controls overlay (top bar with the back button + bottom seek bar) was rendering edge-to-edge alongside the video surface, so on Android the back button collided with the status bar and the seek bar overlapped the gesture-nav area.
- Wrapped the top \`Row\` and bottom \`Column\` in \`PlayerControlsOverlay\` with \`Modifier.windowInsetsPadding(WindowInsets.safeDrawing)\`, applied before the existing \`.padding(16.dp)\`. The video surface itself is unaffected and keeps drawing edge-to-edge — only the controls inset away from the system UI.
- Touched only \`screens/video-player/src/commonMain/kotlin/com/eygraber/jellyfin/screens/video/player/VideoPlayerView.kt\` (+9, -4).

## Test plan

- [x] \`./check\` passes locally
- [ ] Verify on Android device: status bar no longer overlaps the back button; gesture nav area no longer overlaps the seek bar; video surface still extends behind both bars
- [ ] No regression on other platforms — the same modifier is a no-op on Desktop/Web/iOS where there are no system bars

## Notes

Adaptive design / landscape concerns (#241) intentionally left to that issue per the one-PR-per-issue convention.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)