### PR TITLE
#251 Exclude wasmJsBrowserTest from CI test job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,7 +120,7 @@ jobs:
         run: diff <(git ls-files ':(attr:filter=lfs)' | sort) <(git lfs ls-files -n | sort) >/dev/null
 
       - name: Run unit and paparazzi screenshot tests
-        run: ./gradlew allTests testDebugUnitTest :konsist:test
+        run: ./gradlew allTests testDebugUnitTest :konsist:test -x wasmJsBrowserTest
 
 env:
   EJSON_DEV_BUILD_PRIVATE_KEY: ${{ secrets.EJSON_DEV_BUILD_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- The \`unit_and_screenshot_tests\` CI job (re-enabled in #248) hangs on \`:data:items:public:wasmJsBrowserTest\` with a Karma/Chrome handshake timeout (\`Disconnected (0 times), because no message in 30000 ms\`). PR #250's job ran 51 minutes before being killed; every PR after #248 lands the same hang, leaving master with red CI.
- Added \`-x wasmJsBrowserTest\` to the gradle invocation in \`.github/workflows/pr.yml\` so the remainder of \`allTests + testDebugUnitTest + :konsist:test\` runs to completion. The wasmJs browser-test slice was never actually green, so the exclusion isn't a regression — it's just stopping us from gating master on a known-broken task.
- Properly fixing the wasmJs runner (likely flipping \`webOptions\` to Node, or diagnosing the Karma config) is tracked in #251 itself as a follow-up.

## Test plan

- [x] \`./check\` passes locally
- [ ] CI's \`unit_and_screenshot_tests\` job goes green on this PR
- [ ] Subsequent PRs (e.g. #241, #242) no longer block on the wasmJs hang

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)