### PR TITLE
#242 Drive periodic position updates while playing on Android

### DIFF
--- a/services/player/impl/src/androidMain/kotlin/com/eygraber/jellyfin/services/player/impl/AndroidVideoPlayerService.kt
+++ b/services/player/impl/src/androidMain/kotlin/com/eygraber/jellyfin/services/player/impl/AndroidVideoPlayerService.kt
@@ -20,9 +20,16 @@ import com.eygraber.jellyfin.services.player.PlaybackState
 import com.eygraber.jellyfin.services.player.VideoPlayerService
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 /**
  * Android implementation of [VideoPlayerService] using ExoPlayer (Media3).
@@ -39,6 +46,9 @@ class AndroidVideoPlayerService(
   override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
   private var player: ExoPlayer? = null
+
+  private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+  private var positionPollJob: Job? = null
 
   @OptIn(UnstableApi::class)
   override fun initialize(
@@ -75,9 +85,31 @@ class AndroidVideoPlayerService(
   }
 
   override fun release() {
+    positionPollJob?.cancel()
+    positionPollJob = null
     player?.release()
     player = null
     _playbackState.value = PlaybackState.Idle
+  }
+
+  private fun startPositionPolling() {
+    positionPollJob?.cancel()
+    positionPollJob = scope.launch {
+      while(isActive) {
+        delay(POSITION_POLL_INTERVAL_MS)
+        val currentPlayer = player ?: break
+        _playbackState.value = _playbackState.value.copy(
+          currentPositionMs = currentPlayer.currentPosition,
+          bufferedPositionMs = currentPlayer.bufferedPosition,
+          durationMs = currentPlayer.duration.coerceAtLeast(0L),
+        )
+      }
+    }
+  }
+
+  private fun stopPositionPolling() {
+    positionPollJob?.cancel()
+    positionPollJob = null
   }
 
   @OptIn(UnstableApi::class)
@@ -95,6 +127,10 @@ class AndroidVideoPlayerService(
     }
   }
 
+  companion object {
+    private const val POSITION_POLL_INTERVAL_MS = 250L
+  }
+
   private inner class PlayerListener : Player.Listener {
     override fun onPlaybackStateChanged(playbackState: Int) {
       updateState()
@@ -102,6 +138,12 @@ class AndroidVideoPlayerService(
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
       updateState()
+      if(isPlaying) {
+        startPositionPolling()
+      }
+      else {
+        stopPositionPolling()
+      }
     }
 
     override fun onPlayerError(error: PlaybackException) {


### PR DESCRIPTION
## Summary

- ExoPlayer's `Player.Listener` only fires on state transitions (`onIsPlayingChanged`, `onPlaybackStateChanged`), not on a continuous time-progress event. As a result the video player's seek bar and elapsed-time label stayed frozen during playback even though the video was clearly advancing.
- Added a 250 ms polling loop (4 Hz, matches the issue spec) that re-reads `currentPosition` / `bufferedPosition` / `duration` while `isPlaying` is true, driven from `onIsPlayingChanged` and torn down on pause / end / release.
- Polling runs on a screen-scoped `CoroutineScope(Dispatchers.Main + SupervisorJob())`. The job is cancelled in both `stopPositionPolling()` and `release()`; the scope itself outlives multiple init/release cycles since `initialize()` calls `release()` first.
- iOS uses AVFoundation's `addPeriodicTimeObserverForInterval` and JVM uses vlcj's `timeChanged` event, so neither needs the same fix — Android-only change.

## Test plan

- [x] `./gradlew :services:player:impl:compileDebugKotlinAndroid` passes
- [x] `./gradlew :services:player:impl:detektMainAndroid` passes
- [x] `./check` passes locally
- [ ] Verify on Android device: while playing, the elapsed-time label updates ~4×/second and the seek bar moves visibly with playback
- [ ] Pausing freezes the position; resuming continues from the same place
- [ ] Buffered-position indicator updates while buffering ahead

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)