### PR TITLE
#255 Document ./format-before-commit rule for Kotlin edits

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -18,6 +18,12 @@ Claude Code hooks automatically run these tools after editing Kotlin files:
 - `./format` runs after editing `.kt` or `.kts` files (async)
 - `./detekt` runs after editing `.kt` source files (async, skips test files)
 
+## Formatting before commit
+
+The post-edit `./format` hook runs **asynchronously**. If you `git add` and `git commit` immediately after editing a Kotlin file, the commit can capture the **unformatted** version while format finishes after — the pre-push hook (`./check`) silently re-formats and passes, but the commit on the branch is still stale and CI ktlint fails.
+
+Before committing Kotlin changes, run `./format` synchronously yourself (or wait for the async run to finish, then `git diff` to confirm a clean working tree) so the staged version is what ktlint will see in CI.
+
 # Markdown Formatting
 
 ## Tables


### PR DESCRIPTION
## Summary

- The post-edit \`./format\` hook runs **asynchronously**. If \`git add\` + \`git commit\` happen immediately after editing a Kotlin file, the commit can capture the unformatted version even though local \`./check\` passes (pre-push runs \`./format\` again and silently fixes it on disk, but the staged commit is stale).
- This bit PR #253 (#241): CI ktlint failed on a missing space inside an \`if\` because format hadn't finished before \`git add\`.
- Added a "Formatting before commit" subsection to \`.claude/rules/code-quality.md\` so future agents know to run \`./format\` synchronously and verify a clean diff before staging Kotlin edits.

## Test plan

- [x] \`./check\` passes locally
- [ ] No code or tooling changes — doc-only, low risk

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)