### PR TITLE
#243 Reuse a single Skia bitmap for Desktop video frames

### DIFF
--- a/services/player/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/player/impl/JvmVideoPlayerService.kt
+++ b/services/player/impl/src/jvmMain/kotlin/com/eygraber/jellyfin/services/player/impl/JvmVideoPlayerService.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import com.eygraber.jellyfin.di.scopes.ScreenScope
 import com.eygraber.jellyfin.services.player.PlaybackState
@@ -21,6 +21,10 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.ImageInfo
 import uk.co.caprica.vlcj.factory.MediaPlayerFactory
 import uk.co.caprica.vlcj.factory.discovery.NativeDiscovery
 import uk.co.caprica.vlcj.player.base.MediaPlayer
@@ -30,19 +34,21 @@ import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormat
 import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormatCallback
 import uk.co.caprica.vlcj.player.embedded.videosurface.callback.RenderCallback
 import uk.co.caprica.vlcj.player.embedded.videosurface.callback.format.RV32BufferFormat
-import java.awt.image.BufferedImage
-import java.awt.image.DataBufferInt
 import java.nio.ByteBuffer
 
 /**
  * Desktop (JVM) implementation of [VideoPlayerService] using vlcj.
  *
  * Renders video by hooking libvlc's callback video surface: each decoded frame is copied into a
- * [BufferedImage], converted to a Compose [ImageBitmap], and exposed via Compose state. The UI
- * displays it through a regular Compose [Image]. This sidesteps `SwingPanel` entirely, which is
- * what was causing the controls overlay to be hidden on Desktop — interop content from
- * `SwingPanel` paints above Compose's Skia surface regardless of z-order, even with the lightweight
- * `CallbackMediaPlayerComponent` and the `compose.interop.blending` system property.
+ * single Skia [Bitmap] whose pixel storage is reused across frames via [Bitmap.installPixels],
+ * then exposed to Compose through [Bitmap.asComposeImageBitmap]. Both the pixel byte array and
+ * the [Bitmap] live for the duration of a stream session, so steady-state playback only allocates
+ * the cheap [ImageBitmap] wrapper per frame instead of a fresh ~8 MB Skia bitmap.
+ *
+ * Sidesteps `SwingPanel` entirely, which was hiding the controls overlay on Desktop — interop
+ * content from `SwingPanel` paints above Compose's Skia surface regardless of z-order, even with
+ * the lightweight `CallbackMediaPlayerComponent` and the `compose.interop.blending` system
+ * property.
  *
  * Audio uses libvlc's standard output. `--stereo-mode=1` forces a stereo downmix so multichannel
  * sources (e.g. AAC 5.1) play correctly on stereo systems; per-output capability detection is
@@ -59,7 +65,8 @@ class JvmVideoPlayerService : VideoPlayerService {
 
   private var factory: MediaPlayerFactory? = null
   private var player: EmbeddedMediaPlayer? = null
-  private var frameImage: BufferedImage? = null
+  private var frameBitmap: Bitmap? = null
+  private var framePixels: ByteArray? = null
   private var currentFrame by mutableStateOf<ImageBitmap?>(null)
 
   override fun initialize(streamUrl: String, startPositionMs: Long) {
@@ -110,7 +117,9 @@ class JvmVideoPlayerService : VideoPlayerService {
     factory?.release()
     player = null
     factory = null
-    frameImage = null
+    frameBitmap?.close()
+    frameBitmap = null
+    framePixels = null
     currentFrame = null
     _playbackState.value = PlaybackState.Idle
   }
@@ -132,10 +141,25 @@ class JvmVideoPlayerService : VideoPlayerService {
 
   private inner class ImageBufferFormatCallback : BufferFormatCallback {
     override fun getBufferFormat(sourceWidth: Int, sourceHeight: Int): BufferFormat {
-      // Allocate the BufferedImage that frame data will be written into. RV32 is 32-bit packed
-      // pixels in native endian, which matches BufferedImage.TYPE_INT_ARGB on little-endian JVMs
-      // (the only platforms vlcj runs on for Desktop).
-      frameImage = BufferedImage(sourceWidth, sourceHeight, BufferedImage.TYPE_INT_ARGB)
+      // Allocate a Skia bitmap whose pixel storage is reused across every decoded frame. RV32 is
+      // 32-bit native-endian BGRA (the only platforms vlcj runs on for Desktop are little-endian),
+      // which matches Skia's BGRA_8888.
+      val info = ImageInfo(
+        width = sourceWidth,
+        height = sourceHeight,
+        colorType = ColorType.BGRA_8888,
+        alphaType = ColorAlphaType.PREMUL,
+      )
+      val rowBytes = sourceWidth * BYTES_PER_PIXEL
+      val pixels = ByteArray(rowBytes * sourceHeight)
+      val bitmap = Bitmap().apply {
+        // installPixels is the no-copy variant: the bitmap reads directly from `pixels` on every
+        // draw, so refreshing the byte array in `display` reflects in the next composition.
+        installPixels(info, pixels, rowBytes)
+      }
+      frameBitmap?.close()
+      frameBitmap = bitmap
+      framePixels = pixels
       return RV32BufferFormat(sourceWidth, sourceHeight)
     }
 
@@ -154,10 +178,15 @@ class JvmVideoPlayerService : VideoPlayerService {
       displayWidth: Int,
       displayHeight: Int,
     ) {
-      val image = frameImage ?: return
-      val pixels = (image.raster.dataBuffer as DataBufferInt).data
-      nativeBuffers[0].asIntBuffer().get(pixels)
-      currentFrame = image.toComposeImageBitmap()
+      val pixels = framePixels ?: return
+      val bitmap = frameBitmap ?: return
+      val src = nativeBuffers[0]
+      src.position(0)
+      src.get(pixels)
+      // The bitmap's pixel storage is `pixels`, so it now reflects the new frame. Wrap it in a
+      // fresh ImageBitmap each frame so Compose sees a state change and recomposes; the wrapper
+      // is a thin object — no pixel copy.
+      currentFrame = bitmap.asComposeImageBitmap()
     }
 
     override fun unlock(mediaPlayer: MediaPlayer) = Unit
@@ -230,5 +259,6 @@ class JvmVideoPlayerService : VideoPlayerService {
   companion object {
     private val isNativeDiscoverySuccessful: Boolean = NativeDiscovery().discover()
     private const val FULL_BUFFER_PERCENT = 100f
+    private const val BYTES_PER_PIXEL = 4
   }
 }


### PR DESCRIPTION
## Summary

\`JvmVideoPlayerService\` used to allocate a fresh Skia bitmap per frame via \`BufferedImage.toComposeImageBitmap()\` — roughly 8 MB for a 1080p stream, every frame, which dominated steady-state CPU and GC.

This PR drops \`BufferedImage\` entirely. Per stream session it allocates **one** Skia \`Bitmap\` whose pixel storage is a single \`ByteArray\` mutated in place. The vlcj render callback rewrites the byte array per frame; the bitmap reads from those bytes on every draw, so the next composition shows the new frame. Each frame wraps the bitmap in a fresh \`ImageBitmap\` (a thin wrapper — no pixel copy) so Compose sees a state change.

vlcj's \`RV32BufferFormat\` is 32-bit native-endian BGRA, which matches Skia's \`ColorType.BGRA_8888\` on the little-endian Desktop targets vlcj supports.

## Decision: patterns over direct dep

The issue offered two paths:
1. **Direct dep on \`io.github.kdroidfilter:composemediaplayer\`** — would replace our entire libvlc backend. Their JVM impl ships per-OS native binaries (Swift dylib for Mac, C++ DLL for Windows, GStreamer C lib for Linux), and pulls in \`filekit\`, \`androidcontextprovider\`, \`androidx.lifecycle\`, \`kotlinx.datetime\`, plus Cocoapods setup for iOS. That's a much bigger platform commitment than we want, and it changes user-facing runtime requirements (Linux moves from libvlc to GStreamer).
2. **Patterns only** — keep vlcj on Desktop and lift just the rendering trick. ✓ Chose this.

The two specific patterns the issue called out — reusable Skia bitmap on Desktop, DOM-positioned \`<video>\` on Web — don't actually require their library. The Skia trick is generic Skia API usage; the Web trick is DOM positioning logic we can write ourselves.

## Scoped: Desktop now, Web later

The Web half of #243 needs in-browser verification (Compose Multiplatform's canvas transparency / z-ordering on WasmJs is non-trivial), so it's tracked separately as **#257**. This PR ships only the Desktop Skia bitmap reuse — clear, verifiable, no risk of regressing Web in the process.

## Test plan

- [x] \`./gradlew :services:player:impl:compileKotlinJvm\` passes
- [x] \`./gradlew :services:player:impl:detektMainJvm\` passes
- [x] \`./check\` passes locally
- [ ] Verify on Desktop: video plays smoothly; CPU steady-state for 1080p24 dropped vs. main; Compose controls overlay still renders cleanly above the surface
- [ ] No regression in #59 acceptance criteria (play/pause/seek/back, navigation back releases the player)

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)