### PR TITLE
#73 Pin adaptive navigation breakpoints with unit tests

### DIFF
--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffold.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffold.kt
@@ -76,7 +76,7 @@ internal fun JellyfinNavigationSuiteScaffold(
  * drawer at expanded widths and a navigation rail at medium widths, so we compute the type
  * directly from [WindowSizeClass] breakpoints (600dp, 840dp).
  */
-private fun jellyfinNavigationSuiteType(
+internal fun jellyfinNavigationSuiteType(
   windowAdaptiveInfo: WindowAdaptiveInfo,
 ): NavigationSuiteType {
   val sizeClass = windowAdaptiveInfo.windowSizeClass

--- a/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffoldTest.kt
+++ b/nav/src/commonTest/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigationSuiteScaffoldTest.kt
@@ -1,0 +1,55 @@
+package com.eygraber.jellyfin.nav
+
+import androidx.compose.material3.adaptive.Posture
+import androidx.compose.material3.adaptive.WindowAdaptiveInfo
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.window.core.layout.WindowSizeClass
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class JellyfinNavigationSuiteScaffoldTest {
+  @Test
+  fun `compact width picks NavigationBar`() {
+    jellyfinNavigationSuiteType(adaptiveInfoFor(widthDp = 400)) shouldBe NavigationSuiteType.NavigationBar
+  }
+
+  @Test
+  fun `width just below medium breakpoint picks NavigationBar`() {
+    jellyfinNavigationSuiteType(adaptiveInfoFor(widthDp = 599)) shouldBe NavigationSuiteType.NavigationBar
+  }
+
+  @Test
+  fun `medium breakpoint picks NavigationRail`() {
+    jellyfinNavigationSuiteType(adaptiveInfoFor(widthDp = 600)) shouldBe NavigationSuiteType.NavigationRail
+  }
+
+  @Test
+  fun `medium width picks NavigationRail`() {
+    jellyfinNavigationSuiteType(adaptiveInfoFor(widthDp = 720)) shouldBe NavigationSuiteType.NavigationRail
+  }
+
+  @Test
+  fun `width just below expanded breakpoint picks NavigationRail`() {
+    jellyfinNavigationSuiteType(adaptiveInfoFor(widthDp = 839)) shouldBe NavigationSuiteType.NavigationRail
+  }
+
+  @Test
+  fun `expanded breakpoint picks NavigationDrawer`() {
+    jellyfinNavigationSuiteType(adaptiveInfoFor(widthDp = 840)) shouldBe NavigationSuiteType.NavigationDrawer
+  }
+
+  @Test
+  fun `expanded width picks NavigationDrawer`() {
+    jellyfinNavigationSuiteType(adaptiveInfoFor(widthDp = 1440)) shouldBe NavigationSuiteType.NavigationDrawer
+  }
+
+  private fun adaptiveInfoFor(widthDp: Int): WindowAdaptiveInfo =
+    WindowAdaptiveInfo(
+      windowSizeClass = WindowSizeClass(minWidthDp = widthDp, minHeightDp = TEST_HEIGHT_DP),
+      windowPosture = Posture(),
+    )
+
+  companion object {
+    private const val TEST_HEIGHT_DP = 800
+  }
+}


### PR DESCRIPTION
## Summary

The adaptive navigation infrastructure (\`JellyfinNavigationSuiteScaffold\`, \`TopLevelDestinationScene\`, \`TopLevelDestinationSceneStrategy\`) was already shipped in #82 and polished in #213 — \`NavigationSuiteScaffold\` switches automatically between bottom-bar / rail / drawer based on the window size, top-level destinations stay highlighted across modes, and the surrounding suite stays mounted while inner content swaps.

The remaining gap from #73's acceptance criteria was test coverage. \`jellyfinNavigationSuiteType\` decides the navigation surface from a \`WindowAdaptiveInfo\`, but its breakpoint logic wasn't exercised by any test, so a future Material breakpoint change (or a bump in the navigation-suite library) could silently shift our navigation behavior.

This PR:
- Bumps \`jellyfinNavigationSuiteType\` from \`private\` to \`internal\` so it's reachable from \`commonTest\`.
- Adds \`JellyfinNavigationSuiteScaffoldTest\` (commonTest) that pins behavior across both Material breakpoints — \`widthDp\` of 400 / 599 / 600 / 720 / 839 / 840 / 1440 → \`NavigationBar\` / \`NavigationBar\` / \`NavigationRail\` / \`NavigationRail\` / \`NavigationRail\` / \`NavigationDrawer\` / \`NavigationDrawer\`.

## On the breakpoint values

#73's text proposed a 1200dp drawer threshold. The current code (and these tests) use Material's standard 840dp expanded-width threshold instead. That's a deliberate design choice documented in the function's KDoc — Material 3 NavigationDrawer is meant to appear at "expanded" widths (≥840dp), and the rail-to-drawer hand-off feels natural there given our typical content density. Calling it out explicitly so the deviation is on the record rather than buried in code.

## Out of scope

- Platform-native styling on iOS (UITabBar feel) — surfaced in your triage comment on #73 but isn't covered by NavigationSuiteScaffold; would be its own design + implementation effort.
- Window-resize transition smoothness on Desktop — visual only; #213 already addressed the navigation-suite flash specifically, broader resize fluidity is hard to assert in unit tests.

## Test plan

- [x] \`./gradlew :nav:jvmTest\` passes (new tests included)
- [x] \`./gradlew :nav:detektMainJvm\` and \`:nav:detektTestJvm\` pass
- [x] \`./check\` passes locally

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)