### PR TITLE
#264 Fix work-loop tooling caveats and untracked-file noise

### DIFF
--- a/.claude/skills/start-work-loop/scripts/merge-pr.sh
+++ b/.claude/skills/start-work-loop/scripts/merge-pr.sh
@@ -23,6 +23,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+START_WORK_SCRIPTS="$SCRIPT_DIR/../../start-work/scripts"
+
 PR_NUMBER=""
 ADMIN_FLAG=""
 AUTO_FLAG=""
@@ -64,10 +67,28 @@ fi
 
 echo "Merging PR #$PR_NUMBER (rebase, delete branch)..."
 
-if gh pr merge "$PR_NUMBER" --rebase --delete-branch $ADMIN_FLAG $AUTO_FLAG; then
-  echo "PR #$PR_NUMBER merged."
-  exit 0
-else
+if ! gh pr merge "$PR_NUMBER" --rebase --delete-branch $ADMIN_FLAG $AUTO_FLAG; then
   echo "Failed to merge PR #$PR_NUMBER." >&2
   exit 1
 fi
+
+echo "PR #$PR_NUMBER merged."
+
+# GitHub auto-closes issues referenced by closing keywords (Closes #N), but its built-in project
+# automation often fails to flip the project board's Status field from "In Review" to "Done" —
+# leaves merged work stuck in In Review. Do the transition explicitly here so the board stays in
+# sync. Skipped for --auto since the merge hasn't actually happened yet.
+if [[ -z "$AUTO_FLAG" ]]; then
+  CLOSED_ISSUES=$(gh pr view "$PR_NUMBER" --json closingIssuesReferences \
+    --jq '.closingIssuesReferences[].number' 2>/dev/null || true)
+  if [[ -n "$CLOSED_ISSUES" ]]; then
+    while read -r ISSUE_NUMBER; do
+      [[ -z "$ISSUE_NUMBER" ]] && continue
+      "$START_WORK_SCRIPTS/set-issue-status.sh" "$ISSUE_NUMBER" done >/dev/null \
+        && echo "Moved #$ISSUE_NUMBER to Done." \
+        || echo "Warning: failed to move #$ISSUE_NUMBER to Done on the project board." >&2
+    done <<< "$CLOSED_ISSUES"
+  fi
+fi
+
+exit 0

--- a/.claude/skills/start-work-loop/scripts/unblock-issues.sh
+++ b/.claude/skills/start-work-loop/scripts/unblock-issues.sh
@@ -8,7 +8,7 @@
 #
 # Output: List of issues that were unblocked (or would be with --dry-run)
 
-set -e
+set -eo pipefail
 
 OWNER="eygraber"
 REPO="jellyfin-kmp"
@@ -35,7 +35,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Get all blocked issues with details
+# Get all open issues that have at least one OPEN blocker. Closed blockers are pre-filtered out
+# here — once a blocker closes, the issue is no longer blocked by it (whether it closed via PR
+# merge, manual close, or anything else).
 BLOCKED_ISSUES=$(gh api graphql -f query='
 {
   repository(owner: "'"$OWNER"'", name: "'"$REPO"'") {
@@ -53,33 +55,18 @@ BLOCKED_ISSUES=$(gh api graphql -f query='
       }
     }
   }
-}' | jq '[.data.repository.issues.nodes[] | select(.blockedBy.nodes | length > 0)]')
+}' | jq '[.data.repository.issues.nodes[]
+  | .blockedBy.nodes |= map(select(.state == "OPEN"))
+  | select(.blockedBy.nodes | length > 0)]')
 
-# Get issues that are In Review or Done (have PRs)
-ISSUES_WITH_PRS=$(gh api graphql -f query='
-{
-  repository(owner: "'"$OWNER"'", name: "'"$REPO"'") {
-    issues(first: 100) {
-      nodes {
-        number
-        state
-        linkedPullRequests(first: 1) {
-          nodes { number }
-        }
-      }
-    }
-  }
-}' | jq '[.data.repository.issues.nodes[] | select(.linkedPullRequests.nodes | length > 0) | .number]')
-
-# Also check project board status for In Review items
+# An open blocker counts as "resolved enough to unblock" if its PR is up — which on this project
+# is reflected by the board status sitting in In Review. (Done issues are CLOSED and were already
+# filtered out above.)
 IN_REVIEW_ITEMS=$("$START_WORK_SCRIPTS/list-project-items.sh" --status in-review 2>/dev/null | jq '[.[].number]' || echo "[]")
-DONE_ITEMS=$("$START_WORK_SCRIPTS/list-project-items.sh" --status done 2>/dev/null | jq '[.[].number]' || echo "[]")
 
-# Combine: issues with PRs OR in review/done status
-RESOLVED_ISSUES=$(echo "[$ISSUES_WITH_PRS, $IN_REVIEW_ITEMS, $DONE_ITEMS]" | jq 'flatten | unique')
+RESOLVED_ISSUES="$IN_REVIEW_ITEMS"
 
-# Find issues that can be unblocked
-# An issue can be unblocked if ALL its blockers are in RESOLVED_ISSUES
+# An issue can be unblocked if every remaining (OPEN) blocker has its PR up (In Review).
 UNBLOCKABLE=$(echo "$BLOCKED_ISSUES" | jq --argjson resolved "$RESOLVED_ISSUES" '
   [.[] | select(
     .blockedBy.nodes | all(.number as $n | $resolved | index($n))

--- a/.claude/skills/start-work/scripts/get-blocked-issues.sh
+++ b/.claude/skills/start-work/scripts/get-blocked-issues.sh
@@ -34,12 +34,15 @@ if [[ "$DETAILS" == "true" ]]; then
           number
           title
           blockedBy(first: 10) {
-            nodes { number title }
+            nodes { number title state }
           }
         }
       }
     }
-  }' | jq '[.data.repository.issues.nodes[] | select(.blockedBy.nodes | length > 0) | {number, title, blockedBy: [.blockedBy.nodes[] | {number, title}]}]'
+  }' | jq '[.data.repository.issues.nodes[]
+    | .blockedBy.nodes |= map(select(.state == "OPEN"))
+    | select(.blockedBy.nodes | length > 0)
+    | {number, title, blockedBy: [.blockedBy.nodes[] | {number, title}]}]'
 else
   gh api graphql -f query='
   {
@@ -48,10 +51,13 @@ else
         nodes {
           number
           blockedBy(first: 5) {
-            nodes { number }
+            nodes { number state }
           }
         }
       }
     }
-  }' | jq '[.data.repository.issues.nodes[] | select(.blockedBy.nodes | length > 0) | .number]'
+  }' | jq '[.data.repository.issues.nodes[]
+    | .blockedBy.nodes |= map(select(.state == "OPEN"))
+    | select(.blockedBy.nodes | length > 0)
+    | .number]'
 fi

--- a/.claude/skills/start-work/scripts/list-project-items.sh
+++ b/.claude/skills/start-work/scripts/list-project-items.sh
@@ -34,8 +34,9 @@ done
 result=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit "$LIMIT")
 
 if [[ -n "$STATUS" ]]; then
-  # Case-insensitive match and normalize "in-progress" to "In Progress"
-  echo "$result" | jq --arg status "$STATUS" '[.items[] | select(.status | ascii_downcase == ($status | ascii_downcase | gsub("-"; " ")))]'
+  # Case-insensitive match and normalize "in-progress" to "In Progress". `(.status // "")` guards
+  # against project items whose Status field is unset — those would otherwise crash ascii_downcase.
+  echo "$result" | jq --arg status "$STATUS" '[.items[] | select((.status // "") | ascii_downcase == ($status | ascii_downcase | gsub("-"; " ")))]'
 else
   echo "$result" | jq '.items'
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,9 @@ node_modules
 *.dmg
 
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+
+# Kotlin JS
+kotlin-js-store/
 


### PR DESCRIPTION
## Summary

Three independent caveats observed across recent work-loop runs, plus a `.gitignore` gap that surfaces from normal use.

### Script fixes

- **`get-blocked-issues.sh`** counted ALL `blockedBy` nodes including ones whose blocker was already CLOSED, so issues whose only blockers were closed were reported as still blocked. Added `select(.state == "OPEN")` filter in both `--details` and number-only modes.
- **`unblock-issues.sh`** queried `Issue.linkedPullRequests`, a field GitHub's GraphQL schema doesn't have — script errored on every invocation. Removed that query: with closed blockers already filtered out by the `get-blocked` logic above, the only remaining "resolved enough to unblock" signal is project-board "In Review" (PR up but not yet merged). Closed blockers count by being absent from the blocker list rather than by being in a resolved set.
- **`list-project-items.sh`** crashed with `explode input must be a string` when any project item had a null Status field — that broke `unblock-issues.sh` downstream. Guarded with `(.status // "")`.
- **`merge-pr.sh`** relied on GitHub's project-board automation to move issues from In Review to Done after a PR-closed-keyword merge, but that automation is unreliable in practice (observed for #68 and #77, both stuck until manually transitioned). Now reads `closingIssuesReferences` from the merged PR and explicitly runs `set-issue-status.sh <issue> done`, with a warning on failure. Skipped under `--auto` since the merge hasn't actually happened yet.

### `.gitignore`

Added `.claude/scheduled_tasks.lock`, `.claude/worktrees/`, and `kotlin-js-store/` — all surface as untracked from normal use of the harness/tooling.

## Test plan

- [x] `get-blocked-issues.sh --details` returns only issues with at least one OPEN blocker
- [x] `unblock-issues.sh --dry-run` runs without GraphQL errors
- [x] `list-project-items.sh --status in-review` returns `[]` cleanly when no items match
- [x] `merge-pr.sh --help` parses, syntax-clean
- [ ] CI checks pass

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)