### PR TITLE
#284 Bump project-list page size so recent issues aren't truncated

### DIFF
--- a/.claude/skills/manage-work/scripts/set-project-status.sh
+++ b/.claude/skills/manage-work/scripts/set-project-status.sh
@@ -40,8 +40,10 @@ fi
 
 STATUS_OPTION_ID="${STATUS_IDS[$STATUS]}"
 
-# Get the project item ID for this issue
-ITEM_ID=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 100 | \
+# Get the project item ID for this issue. Use a high page size so newly-added items don't fall
+# outside the window (the project list grows unbounded over time; the previous default of 100 was
+# silently truncating recent issues and reporting them as "not found in project").
+ITEM_ID=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 1000 | \
   jq -r --argjson num "$ISSUE_NUMBER" '.items[] | select(.content.number == $num) | .id')
 
 if [[ -z "$ITEM_ID" ]]; then

--- a/.claude/skills/start-work/scripts/set-issue-status.sh
+++ b/.claude/skills/start-work/scripts/set-issue-status.sh
@@ -40,8 +40,10 @@ fi
 
 STATUS_OPTION_ID="${STATUS_IDS[$STATUS]}"
 
-# Get the project item ID for this issue
-ITEM_ID=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 100 | \
+# Get the project item ID for this issue. Use a high page size so newly-added items don't fall
+# outside the window (the project list grows unbounded over time; the previous default of 100 was
+# silently truncating recent issues and reporting them as "not found in project").
+ITEM_ID=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 1000 | \
   jq -r --argjson num "$ISSUE_NUMBER" '.items[] | select(.content.number == $num) | .id')
 
 if [[ -z "$ITEM_ID" ]]; then


### PR DESCRIPTION
## Summary

Two scripts (`set-issue-status.sh` and `set-project-status.sh`) hardcoded `--limit 100` on `gh project item-list`. The board now has 113+ items, so newly-filed issues silently fell out of the window and the scripts reported `Issue #N not found in project`. Bumped both to `--limit 1000` with an inline comment explaining the gotcha.

## Hit while

Bulk-moving the 12 fresh P0 bug issues plus the audio Phase 1 foundation to Ready. Issues #266-#270 worked, #271 onward all failed until I raised the limit.

## Test plan

- [x] `set-issue-status.sh <issue> ready` works for the previously-failing issue numbers
- [ ] CI passes

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)