### PR TITLE
#288 Add SQLDelight database driver for Web (WasmJs) using OPFS

### DIFF
--- a/apps/web/webpack.config.d/boilerplate.js
+++ b/apps/web/webpack.config.d/boilerplate.js
@@ -3,5 +3,5 @@ if(config.devServer) {
     rewrites: [
       { from: /.*jellyfin-wasm.wasm/, to: '/jellyfin-wasm.wasm' },
     ]
-  }
+  };
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,9 +59,9 @@ publish = "0.36.0"
 
 robolectric = "4.16.1"
 
-androidx-sqlite = "2.6.2"
+androidx-sqlite = "2.7.0-alpha03"
 
-sqldelight-androidx-driver = "0.1.1"
+sqldelight-androidx-driver = "0.5.0-alpha.6"
 
 square-sqldelight = "2.3.2"
 
@@ -127,6 +127,7 @@ androidx-media3-ui-compose = { module = "androidx.media3:media3-ui-compose", ver
 androidx-splash = "androidx.core:core-splashscreen:1.2.0"
 
 androidx-sqliteBundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "androidx-sqlite" }
+androidx-sqliteWeb = { module = "androidx.sqlite:sqlite-web", version.ref = "androidx-sqlite" }
 
 androidx-startup = "androidx.startup:startup-runtime:1.2.0"
 
@@ -207,6 +208,7 @@ libphonenumber = "io.github.luca992.libphonenumber-kotlin:libphonenumber:0.1.9"
 square-molecule = "app.cash.molecule:molecule-runtime:2.2.0"
 square-seismic = "com.squareup:seismic:1.0.3"
 sqldelight-androidx-driver = { module = "com.eygraber:sqldelight-androidx-driver", version.ref = "sqldelight-androidx-driver" }
+sqldelight-androidx-driverOpfs = { module = "com.eygraber:sqldelight-androidx-driver-opfs", version.ref = "sqldelight-androidx-driver" }
 
 square-sqldelight-android = { module = "app.cash.sqldelight:android-driver", version.ref = "square-sqldelight" }
 square-sqldelight-dialect = { module = "app.cash.sqldelight:sqlite-3-38-dialect", version.ref = "square-sqldelight" }

--- a/services/database/impl/build.gradle.kts
+++ b/services/database/impl/build.gradle.kts
@@ -37,6 +37,8 @@ kotlin {
       implementation(projects.di)
 
       api(libs.kotlinx.coroutines.core)
+
+      implementation(libs.sqldelight.androidx.driver)
     }
 
     commonTest.dependencies {
@@ -48,26 +50,23 @@ kotlin {
 
     jvmTest.dependencies {
       implementation(libs.androidx.sqliteBundled)
-      implementation(libs.sqldelight.androidx.driver)
     }
 
     androidMain.dependencies {
       implementation(libs.androidx.sqliteBundled)
-      implementation(libs.sqldelight.androidx.driver)
     }
 
     iosMain.dependencies {
       implementation(libs.androidx.sqliteBundled)
-      implementation(libs.sqldelight.androidx.driver)
     }
 
     jvmMain.dependencies {
       implementation(libs.androidx.sqliteBundled)
-      implementation(libs.sqldelight.androidx.driver)
     }
 
-    // WasmJs database support requires SQLDelight's async web worker driver
-    // which needs generateAsync=true. This will be implemented in a future issue.
-    // For now, WasmJs uses a stub driver.
+    webMain.dependencies {
+      implementation(libs.androidx.sqliteWeb)
+      implementation(libs.sqldelight.androidx.driverOpfs)
+    }
   }
 }

--- a/services/database/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.wasmJs.kt
+++ b/services/database/impl/src/wasmJsMain/kotlin/com/eygraber/jellyfin/services/database/impl/PlatformDatabaseDriver.wasmJs.kt
@@ -1,21 +1,30 @@
 package com.eygraber.jellyfin.services.database.impl
 
 import app.cash.sqldelight.db.SqlDriver
+import com.eygraber.jellyfin.services.database.DatabaseConfig
 import com.eygraber.jellyfin.services.database.JellyfinDatabaseProvider
+import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConfiguration
+import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
+import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDriver
+import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode.WAL
+import com.eygraber.sqldelight.androidx.driver.opfs.OpfsMultiTabMode
+import com.eygraber.sqldelight.androidx.driver.opfs.androidxSqliteOpfsDriver
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 
-/**
- * WasmJs database support is not yet implemented.
- *
- * SQLDelight's web worker driver requires `generateAsync = true` which changes the
- * generated API for all platforms. Full WasmJs support will be added in a future issue
- * using the async web worker driver.
- */
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-internal class WasmJsJellyfinDatabaseProvider : JellyfinDatabaseProvider {
-  override fun createDriver(): SqlDriver =
-    error("Database is not yet supported on WasmJs.")
+internal class WasmJsJellyfinDatabaseProvider(
+  private val config: DatabaseConfig,
+) : JellyfinDatabaseProvider {
+  override fun createDriver(): SqlDriver = AndroidxSqliteDriver(
+    driver = androidxSqliteOpfsDriver(OpfsMultiTabMode.Shared),
+    databaseType = AndroidxSqliteDatabaseType.File(config.databaseName),
+    schema = JellyfinDatabase.Schema,
+    configuration = AndroidxSqliteConfiguration(
+      isForeignKeyConstraintsEnabled = true,
+      journalMode = WAL,
+    ),
+  )
 }


### PR DESCRIPTION
## Summary
- Wires up a real WasmJs `JellyfinDatabaseProvider` using `com.eygraber:sqldelight-androidx-driver-opfs` (OPFS, multi-tab Shared) on top of `androidx.sqlite:sqlite-web`, replacing the previous stub that threw `error("Database is not yet supported on WasmJs.")`.
- Bumps `androidx-sqlite` to `2.7.0-alpha03` and `sqldelight-androidx-driver` to `0.5.0-alpha.3`, and moves the `sqldelight-androidx-driver` dependency into `commonMain` so all platforms share the same `AndroidxSqliteDriver` abstraction.
- Adds a `webMain` source-set block depending on the OPFS driver + `sqlite-web`, and fixes a missing semicolon in `apps/web/webpack.config.d/boilerplate.js`.

> [!NOTE]
> CI is expected to fail until `com.eygraber:sqldelight-androidx-driver:0.5.0-alpha.6` finishes publishing to Maven Central. Auto-merge will be enabled once the artifact is available and checks pass.

Closes #288

## Test plan
- [ ] `./check` passes once the new artifact versions are resolvable
- [ ] Web app can persist data via the shared `JellyfinDatabaseProvider` contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)