### PR TITLE
#267 Navigate Home item taps to real Item Detail screens

### DIFF
--- a/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
+++ b/nav/src/commonMain/kotlin/com/eygraber/jellyfin/nav/JellyfinNavigators.kt
@@ -74,8 +74,13 @@ internal object JellyfinNavigators {
     backStack: NavBackStack<NavKey>,
   ) = HomeNavigator(
     onNavigateBack = { backStack.removeLastOrNull() },
-    onNavigateToItemDetail = { itemId ->
-      backStack.add(JellyfinNavKeys.ComingSoon("Item Detail ($itemId)"))
+    onNavigateToItemDetail = { itemId, itemType ->
+      when(itemType) {
+        "Movie" -> backStack.add(MovieDetailKey(movieId = itemId))
+        "Series" -> backStack.add(TvShowDetailKey(seriesId = itemId))
+        "Episode" -> backStack.add(EpisodeDetailKey(episodeId = itemId))
+        else -> backStack.add(JellyfinNavKeys.ComingSoon("$itemType Detail ($itemId)"))
+      }
     },
     onNavigateToLibrary = { libraryId, collectionType ->
       when(collectionType) {

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeCompositor.kt
@@ -58,9 +58,18 @@ class HomeCompositor(
       HomeIntent.RetryLoad -> retryLoad()
       HomeIntent.SearchClicked -> navigator.navigateToSearch()
       HomeIntent.SettingsClicked -> navigator.navigateToSettings()
-      is HomeIntent.ContinueWatchingItemClicked -> navigator.navigateToItemDetail(intent.itemId)
-      is HomeIntent.NextUpItemClicked -> navigator.navigateToItemDetail(intent.itemId)
-      is HomeIntent.RecentlyAddedItemClicked -> navigator.navigateToItemDetail(intent.itemId)
+      is HomeIntent.ContinueWatchingItemClicked -> navigator.navigateToItemDetail(
+        itemId = intent.itemId,
+        itemType = intent.itemType,
+      )
+      is HomeIntent.NextUpItemClicked -> navigator.navigateToItemDetail(
+        itemId = intent.itemId,
+        itemType = NEXT_UP_ITEM_TYPE,
+      )
+      is HomeIntent.RecentlyAddedItemClicked -> navigator.navigateToItemDetail(
+        itemId = intent.itemId,
+        itemType = intent.itemType,
+      )
       is HomeIntent.LibraryClicked -> navigator.navigateToLibrary(
         libraryId = intent.libraryId,
         collectionType = intent.collectionType,
@@ -92,5 +101,10 @@ class HomeCompositor(
     if(!isValid) {
       error = HomeError.Network()
     }
+  }
+
+  private companion object {
+    // Next Up rows always come from getNextUpEpisodes, so the item type is fixed.
+    const val NEXT_UP_ITEM_TYPE = "Episode"
   }
 }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeIntent.kt
@@ -5,9 +5,9 @@ sealed interface HomeIntent {
   data object RetryLoad : HomeIntent
   data object SearchClicked : HomeIntent
   data object SettingsClicked : HomeIntent
-  data class ContinueWatchingItemClicked(val itemId: String) : HomeIntent
+  data class ContinueWatchingItemClicked(val itemId: String, val itemType: String) : HomeIntent
   data class NextUpItemClicked(val itemId: String) : HomeIntent
-  data class RecentlyAddedItemClicked(val itemId: String) : HomeIntent
+  data class RecentlyAddedItemClicked(val itemId: String, val itemType: String) : HomeIntent
   data class LibraryClicked(
     val libraryId: String,
     val collectionType: CollectionType,

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeNavigator.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeNavigator.kt
@@ -2,7 +2,7 @@ package com.eygraber.jellyfin.screens.home
 
 class HomeNavigator(
   private val onNavigateBack: () -> Unit,
-  private val onNavigateToItemDetail: (itemId: String) -> Unit,
+  private val onNavigateToItemDetail: (itemId: String, itemType: String) -> Unit,
   private val onNavigateToLibrary: (libraryId: String, collectionType: CollectionType) -> Unit,
   private val onNavigateToSearch: () -> Unit,
   private val onNavigateToSettings: () -> Unit,
@@ -11,8 +11,8 @@ class HomeNavigator(
     onNavigateBack()
   }
 
-  fun navigateToItemDetail(itemId: String) {
-    onNavigateToItemDetail(itemId)
+  fun navigateToItemDetail(itemId: String, itemType: String) {
+    onNavigateToItemDetail(itemId, itemType)
   }
 
   fun navigateToLibrary(libraryId: String, collectionType: CollectionType) {

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/HomeView.kt
@@ -131,7 +131,9 @@ private fun HomeContent(
 
     ContinueWatchingSection(
       state = state.continueWatchingState,
-      onItemClick = { itemId -> onIntent(HomeIntent.ContinueWatchingItemClicked(itemId)) },
+      onItemClick = { itemId, itemType ->
+        onIntent(HomeIntent.ContinueWatchingItemClicked(itemId = itemId, itemType = itemType))
+      },
     )
 
     NextUpSection(
@@ -148,7 +150,9 @@ private fun HomeContent(
 
     RecentlyAddedHomeSection(
       state = state.recentlyAddedState,
-      onItemClick = { itemId -> onIntent(HomeIntent.RecentlyAddedItemClicked(itemId)) },
+      onItemClick = { itemId, itemType ->
+        onIntent(HomeIntent.RecentlyAddedItemClicked(itemId = itemId, itemType = itemType))
+      },
     )
 
     Spacer(modifier = Modifier.height(16.dp))
@@ -158,7 +162,7 @@ private fun HomeContent(
 @Composable
 private fun ContinueWatchingSection(
   state: ContinueWatchingState,
-  onItemClick: (itemId: String) -> Unit,
+  onItemClick: (itemId: String, itemType: String) -> Unit,
 ) {
   when(state) {
     is ContinueWatchingState.Loading -> ContinueWatchingLoading()
@@ -199,7 +203,7 @@ private fun NextUpSection(
 @Composable
 private fun RecentlyAddedHomeSection(
   state: RecentlyAddedState,
-  onItemClick: (itemId: String) -> Unit,
+  onItemClick: (itemId: String, itemType: String) -> Unit,
 ) {
   when(state) {
     is RecentlyAddedState.Loading -> Unit

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/ContinueWatchingRow.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/ContinueWatchingRow.kt
@@ -18,7 +18,7 @@ import com.eygraber.jellyfin.screens.home.ContinueWatchingItem
 @Composable
 internal fun ContinueWatchingRow(
   items: List<ContinueWatchingItem>,
-  onItemClick: (itemId: String) -> Unit,
+  onItemClick: (itemId: String, itemType: String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Column(modifier = modifier) {
@@ -40,7 +40,7 @@ internal fun ContinueWatchingRow(
       ) { item ->
         MediaCardWithProgress(
           item = item,
-          onClick = { onItemClick(item.id) },
+          onClick = { onItemClick(item.id, item.type) },
         )
       }
     }

--- a/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/RecentlyAddedSection.kt
+++ b/screens/home/src/commonMain/kotlin/com/eygraber/jellyfin/screens/home/components/RecentlyAddedSection.kt
@@ -25,7 +25,7 @@ import com.eygraber.jellyfin.screens.home.RecentlyAddedItem
 @Composable
 internal fun RecentlyAddedSection(
   items: List<RecentlyAddedItem>,
-  onItemClick: (itemId: String) -> Unit,
+  onItemClick: (itemId: String, itemType: String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Column(modifier = modifier) {
@@ -47,7 +47,7 @@ internal fun RecentlyAddedSection(
       ) { item ->
         RecentlyAddedCard(
           item = item,
-          onClick = { onItemClick(item.id) },
+          onClick = { onItemClick(item.id, item.type) },
         )
       }
     }


### PR DESCRIPTION
Closes #267

## Summary

- Home rows (Continue Watching, Next Up, Recently Added) now dispatch to the real Movie/Series/Episode detail screens instead of pushing a `ComingSoon` placeholder.
- Threads `itemType` through `HomeIntent.ContinueWatchingItemClicked` / `RecentlyAddedItemClicked` (Next Up rows are always episodes, so the compositor passes a fixed `"Episode"` type).
- `JellyfinNavigators.home` now mirrors the type-based dispatch already used by `JellyfinNavigators.search` (`Movie` -> `MovieDetailKey`, `Series` -> `TvShowDetailKey`, `Episode` -> `EpisodeDetailKey`, fallback to `ComingSoon`).

## Test plan

- [ ] Tap a Continue Watching item (movie or episode) on Home -> navigates to the correct detail screen
- [ ] Tap a Next Up item on Home -> navigates to Episode Detail
- [ ] Tap a Recently Added movie/series on Home -> navigates to the corresponding detail screen
- [ ] `./check` passes