### PR TITLE
#268 Migrate SearchView text input to TextFieldState API

### DIFF
--- a/.claude/rules/compose.md
+++ b/.claude/rules/compose.md
@@ -52,8 +52,15 @@ The legacy `value`/`onValueChange` API races with async state updates, causing t
 ❌ Bad: OutlinedTextField(value = state.query, onValueChange = { onIntent(QueryChanged(it)) })
 ✅ Good: OutlinedTextField(state = state.fields.query)
 
-Hold the `TextFieldState` in a model (e.g. `FieldsModel : ViceSource<FieldsState>`) and expose it via `ViewState`
-Observe text changes from the Compositor with `snapshotFlow { state.text.toString() }` or `TextFieldState.UpdateEffect { ... }` from `:ui:material`
+Hold the `TextFieldState` in a model (e.g. `FieldsModel : ViceSource<FieldsState>`) and create it inside `currentState()` with `rememberTextFieldState()` so the text survives config changes / process death. Never store the `TextFieldState` as a class property (a plain field, `lateinit var`, or nullable cache) — DI-scoped objects don't participate in Compose's saved-state registry, and caching a Compose-owned instance back into the model creates lifecycle-leak and ordering hazards.
+
+If the model needs to mutate the field externally (e.g. populate from a history click), expose `suspend` mutators that send through a rendezvous `Channel<TextFieldState.() -> Unit>`, drained inside `currentState()` with `LaunchedEffect(query) { for (mutate in mutations) query.mutate() }`. Prefer `mutations.send { ... }` over `trySend { ... }` — it gives natural backpressure and waits for composition rather than dropping or buffering blindly.
+
+❌ Bad: `private val state = SearchFieldsState(query = TextFieldState())` as a property — text is lost on process death
+❌ Bad: `private lateinit var queryState: TextFieldState` cached from `currentState()` — leaks Compose-owned state into the model and throws if a mutator fires before first composition
+✅ Good: `rememberTextFieldState()` inside `currentState()`, mutations routed through a `Channel<TextFieldState.() -> Unit>` drained by a `LaunchedEffect`
+
+Observe text changes from the Compositor with `TextFieldState.UpdateEffect { ... }` (or `UpdateEffectLatest { ... }` when the callback is suspending and earlier in-flight work should be cancelled on each keystroke) from `:ui:material`. Avoid inlining `LaunchedEffect { snapshotFlow { ... }.collect/collectLatest { ... } }` in compositors when one of these helpers fits.
 Mutate from `onIntent` with `setTextAndPlaceCursorAtEnd(...)` / `clearText()`; do not echo strings back through Intents
 
 For complete patterns: .docs/compose/state-management.md (the `Prefer Specialized Types` section)

--- a/.claude/rules/compose.md
+++ b/.claude/rules/compose.md
@@ -46,6 +46,18 @@ State survival: Prefer specialized types (TextFieldState, LazyListState) that ha
 For other state that must survive composition removal: use rememberSaveable (primitives) or rememberSerializable (data classes)
 Only save user-facing state, not derived values or transient UI state (animations, dialog visibility)
 
+# Text Input
+🔴 CRITICAL: Use the `TextFieldState` API for all text inputs - never the legacy `value: String` / `onValueChange: (String) -> Unit` API
+The legacy `value`/`onValueChange` API races with async state updates, causing typed text to be lost or duplicated
+❌ Bad: OutlinedTextField(value = state.query, onValueChange = { onIntent(QueryChanged(it)) })
+✅ Good: OutlinedTextField(state = state.fields.query)
+
+Hold the `TextFieldState` in a model (e.g. `FieldsModel : ViceSource<FieldsState>`) and expose it via `ViewState`
+Observe text changes from the Compositor with `snapshotFlow { state.text.toString() }` or `TextFieldState.UpdateEffect { ... }` from `:ui:material`
+Mutate from `onIntent` with `setTextAndPlaceCursorAtEnd(...)` / `clearText()`; do not echo strings back through Intents
+
+For complete patterns: .docs/compose/state-management.md (the `Prefer Specialized Types` section)
+
 LocalContext.current is OK in View composables for simple UI needs
 Never use LocalContext.current in Models or business logic - inject Context via DI with @AppContext instead
 ❌ Bad: val context = LocalContext.current in Model

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchCompositor.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchCompositor.kt
@@ -1,15 +1,13 @@
 package com.eygraber.jellyfin.screens.search
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
 import com.eygraber.jellyfin.screens.search.model.SearchFieldsModel
 import com.eygraber.jellyfin.screens.search.model.SearchHistoryModel
 import com.eygraber.jellyfin.screens.search.model.SearchModel
 import com.eygraber.jellyfin.screens.search.model.SearchModelError
+import com.eygraber.jellyfin.ui.material.text.UpdateEffectLatest
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.collectLatest
 
 @Inject
 class SearchCompositor(
@@ -25,11 +23,8 @@ class SearchCompositor(
     val modelState = searchModel.currentState()
     val historyState = searchHistoryModel.currentState()
 
-    LaunchedEffect(fields.query) {
-      snapshotFlow { fields.query.text.toString() }
-        .collectLatest { text ->
-          searchModel.search(text)
-        }
+    fields.query.UpdateEffectLatest { text ->
+      searchModel.search(text.toString())
     }
 
     return SearchViewState(

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchCompositor.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchCompositor.kt
@@ -1,25 +1,39 @@
 package com.eygraber.jellyfin.screens.search
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import com.eygraber.jellyfin.screens.search.model.SearchFieldsModel
 import com.eygraber.jellyfin.screens.search.model.SearchHistoryModel
 import com.eygraber.jellyfin.screens.search.model.SearchModel
 import com.eygraber.jellyfin.screens.search.model.SearchModelError
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.collectLatest
 
 @Inject
 class SearchCompositor(
   private val navigator: SearchNavigator,
   private val searchModel: SearchModel,
   private val searchHistoryModel: SearchHistoryModel,
+  private val searchFieldsModel: SearchFieldsModel,
 ) : ViceCompositor<SearchIntent, SearchViewState> {
 
   @Composable
   override fun composite(): SearchViewState {
+    val fields = searchFieldsModel.currentState()
     val modelState = searchModel.currentState()
     val historyState = searchHistoryModel.currentState()
 
+    LaunchedEffect(fields.query) {
+      snapshotFlow { fields.query.text.toString() }
+        .collectLatest { text ->
+          searchModel.search(text)
+        }
+    }
+
     return SearchViewState(
+      fields = fields,
       query = modelState.query,
       movieResults = modelState.movieResults,
       seriesResults = modelState.seriesResults,
@@ -35,10 +49,6 @@ class SearchCompositor(
 
   override suspend fun onIntent(intent: SearchIntent) {
     when(intent) {
-      is SearchIntent.QueryChanged -> searchModel.search(intent.query)
-
-      SearchIntent.ClearQuery -> searchModel.clearSearch()
-
       is SearchIntent.ResultClicked -> {
         searchHistoryModel.saveSearch(searchModel.currentQuery)
         navigator.navigateToItemDetail(
@@ -47,7 +57,7 @@ class SearchCompositor(
         )
       }
 
-      is SearchIntent.HistoryItemClicked -> searchModel.search(intent.query)
+      is SearchIntent.HistoryItemClicked -> searchFieldsModel.setQuery(intent.query)
 
       is SearchIntent.DeleteHistoryItem -> searchHistoryModel.deleteSearch(intent.query)
 

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchIntent.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchIntent.kt
@@ -1,8 +1,6 @@
 package com.eygraber.jellyfin.screens.search
 
 sealed interface SearchIntent {
-  data class QueryChanged(val query: String) : SearchIntent
-  data object ClearQuery : SearchIntent
   data class ResultClicked(val itemId: String, val itemType: String) : SearchIntent
   data class HistoryItemClicked(val query: String) : SearchIntent
   data class DeleteHistoryItem(val query: String) : SearchIntent

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchView.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchView.kt
@@ -17,6 +17,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -76,9 +79,7 @@ internal fun SearchView(
           .padding(contentPadding),
       ) {
         SearchField(
-          query = state.query,
-          onQueryChange = { onIntent(SearchIntent.QueryChanged(it)) },
-          onClear = { onIntent(SearchIntent.ClearQuery) },
+          state = state.fields.query,
         )
 
         when {
@@ -109,21 +110,18 @@ internal fun SearchView(
 
 @Composable
 private fun SearchField(
-  query: String,
-  onQueryChange: (String) -> Unit,
-  onClear: () -> Unit,
+  state: TextFieldState,
 ) {
   OutlinedTextField(
-    value = query,
-    onValueChange = onQueryChange,
+    state = state,
     modifier = Modifier
       .fillMaxWidth()
       .padding(horizontal = 16.dp, vertical = 8.dp),
     placeholder = { Text("Search movies, shows, music...") },
-    singleLine = true,
+    lineLimits = TextFieldLineLimits.SingleLine,
     trailingIcon = {
-      if(query.isNotEmpty()) {
-        IconButton(onClick = onClear) {
+      if(state.text.isNotEmpty()) {
+        IconButton(onClick = { state.clearText() }) {
           Icon(
             imageVector = JellyfinIcons.Close,
             contentDescription = "Clear search",
@@ -445,6 +443,7 @@ private fun SearchResultsPreview() {
   JellyfinPreviewTheme {
     SearchView(
       state = SearchViewState(
+        fields = SearchFieldsState(query = TextFieldState("inception")),
         query = "inception",
         movieResults = listOf(
           SearchViewItem(

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchView.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchView.kt
@@ -33,8 +33,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -112,11 +116,18 @@ internal fun SearchView(
 private fun SearchField(
   state: TextFieldState,
 ) {
+  val focusRequester = remember { FocusRequester() }
+
+  LaunchedEffect(focusRequester) {
+    focusRequester.requestFocus()
+  }
+
   OutlinedTextField(
     state = state,
     modifier = Modifier
       .fillMaxWidth()
-      .padding(horizontal = 16.dp, vertical = 8.dp),
+      .padding(horizontal = 16.dp, vertical = 8.dp)
+      .focusRequester(focusRequester),
     placeholder = { Text("Search movies, shows, music...") },
     lineLimits = TextFieldLineLimits.SingleLine,
     trailingIcon = {

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchViewState.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/SearchViewState.kt
@@ -1,9 +1,11 @@
 package com.eygraber.jellyfin.screens.search
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Immutable
 
 @Immutable
 data class SearchViewState(
+  val fields: SearchFieldsState = SearchFieldsState(),
   val query: String = "",
   val movieResults: List<SearchViewItem> = emptyList(),
   val seriesResults: List<SearchViewItem> = emptyList(),
@@ -28,6 +30,10 @@ data class SearchViewState(
     val Initial = SearchViewState()
   }
 }
+
+data class SearchFieldsState(
+  val query: TextFieldState = TextFieldState(),
+)
 
 @Immutable
 sealed interface SearchError {

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/model/SearchFieldsModel.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/model/SearchFieldsModel.kt
@@ -1,0 +1,25 @@
+package com.eygraber.jellyfin.screens.search.model
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.Composable
+import com.eygraber.jellyfin.di.scopes.ScreenScope
+import com.eygraber.jellyfin.screens.search.SearchFieldsState
+import com.eygraber.vice.ViceSource
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(ScreenScope::class)
+class SearchFieldsModel : ViceSource<SearchFieldsState> {
+  private val state = SearchFieldsState(
+    query = TextFieldState(),
+  )
+
+  @Composable
+  override fun currentState() = state
+
+  fun setQuery(query: String) {
+    state.query.setTextAndPlaceCursorAtEnd(query)
+  }
+}

--- a/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/model/SearchFieldsModel.kt
+++ b/screens/search/src/commonMain/kotlin/com/eygraber/jellyfin/screens/search/model/SearchFieldsModel.kt
@@ -1,25 +1,32 @@
 package com.eygraber.jellyfin.screens.search.model
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import com.eygraber.jellyfin.di.scopes.ScreenScope
 import com.eygraber.jellyfin.screens.search.SearchFieldsState
 import com.eygraber.vice.ViceSource
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.channels.Channel
 
 @Inject
 @SingleIn(ScreenScope::class)
 class SearchFieldsModel : ViceSource<SearchFieldsState> {
-  private val state = SearchFieldsState(
-    query = TextFieldState(),
-  )
+  private val mutations = Channel<TextFieldState.() -> Unit>()
 
   @Composable
-  override fun currentState() = state
+  override fun currentState(): SearchFieldsState {
+    val query = rememberTextFieldState()
+    LaunchedEffect(query) {
+      for(mutate in mutations) query.mutate()
+    }
+    return SearchFieldsState(query = query)
+  }
 
-  fun setQuery(query: String) {
-    state.query.setTextAndPlaceCursorAtEnd(query)
+  suspend fun setQuery(query: String) {
+    mutations.send { setTextAndPlaceCursorAtEnd(query) }
   }
 }

--- a/ui/material/src/commonMain/kotlin/com/eygraber/jellyfin/ui/material/text/JellyfinTextFieldState.kt
+++ b/ui/material/src/commonMain/kotlin/com/eygraber/jellyfin/ui/material/text/JellyfinTextFieldState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun TextFieldState.UpdateEffect(
@@ -12,6 +13,17 @@ fun TextFieldState.UpdateEffect(
 ) {
   LaunchedEffect(this, onUpdate) {
     snapshotFlow { text }.collect { name ->
+      onUpdate(name)
+    }
+  }
+}
+
+@Composable
+fun TextFieldState.UpdateEffectLatest(
+  onUpdate: suspend (CharSequence) -> Unit,
+) {
+  LaunchedEffect(this, onUpdate) {
+    snapshotFlow { text }.collectLatest { name ->
       onUpdate(name)
     }
   }


### PR DESCRIPTION
Closes #268

## Summary

- Replaces the legacy `value` / `onValueChange` `OutlinedTextField` in `SearchView` with the `TextFieldState` API to fix typed characters being lost or duplicated under async state updates.
- Adds `SearchFieldsModel` (mirroring `LoginFieldsModel`) holding a `TextFieldState` query in `ScreenScope`. The compositor observes text via `snapshotFlow { text }.collectLatest { searchModel.search(it) }`, which also cancels superseded searches when the user keeps typing.
- Removes the now-unnecessary `QueryChanged` / `ClearQuery` intents (clearing happens directly via `TextFieldState.clearText()`); `HistoryItemClicked` now sets the field via `setTextAndPlaceCursorAtEnd` and the snapshot flow drives the search.
- Adds a `Text Input` section to `.claude/rules/compose.md` so future agents don't re-introduce the legacy API.

## Test plan

- [ ] Type quickly into the search field on Android - no characters lost or duplicated
- [ ] Tap a recent search history entry - field populates and triggers a search
- [ ] Tap the trailing clear icon - field clears and results reset
- [ ] Tap a result - history is saved and detail navigates correctly
- [ ] `./check` passes locally