### PR TITLE
#296 Skip DAGP buildHealth/projectHealth until KMP support is validated

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -4,7 +4,7 @@ Run Android lint on app module for performance: ./gradlew :app:lintRelease
 Use Detekt for static analysis (both with and without type resolution)
 Never modify detekt.yml files without permission
 detekt.yml files can be read to provide context on why a violation may be occurring
-Use Dependency Analysis Plugin to verify correct dependency configurations
+Do not run DAGP tasks (`buildHealth`, `projectHealth`) — they don't currently work with KMP modules in this project. Skip until validated with KMP.
 Use Konsist tests to enforce architectural rules
 Format violations should be fixed automatically with ./format script
 Detekt runs in two modes: no type resolution and with type resolution

--- a/.claude/rules/gradle-build.md
+++ b/.claude/rules/gradle-build.md
@@ -14,7 +14,6 @@ Run snapshot tests: ./gradlew verifyPaparazziDebug
 Format code: ./format
 Run detekt: ./detekt
 Run Android lint: ./gradlew :app:lintRelease
-Check dependency usage: ./gradlew buildHealth
 Check licenses: ./gradlew licenseeAndroidRelease
 Run full checks: ./check
 If Compose Resources are used in a module, Android resources needs to be enabled (see .claude/rules/examples/android-resources.gradle.kts for an example)

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -30,7 +30,6 @@ Runs: formatting, detekt, lint, unit tests, screenshot tests, konsist.
 | Module Tests      | `./gradlew :module:testDebugUnitTest` | Single module                      |
 | Screenshots       | `./gradlew verifyPaparazziDebug`      | Screenshot tests                   |
 | Konsist           | `./gradlew :konsist:test`             | Structural and architectural tests |
-| Build Health      | `./gradlew buildHealth`               | Dependency analysis                |
 
 #### Formatting
 

--- a/.docs/workflow/builds.md
+++ b/.docs/workflow/builds.md
@@ -59,8 +59,8 @@ Gradle commands for Jellyfin.
 # Konsist
 ./gradlew :konsist:test
 
-# Dependency analysis
-./gradlew buildHealth
+# Dependency analysis (DAGP) — currently broken on KMP modules; do not run until validated.
+# ./gradlew buildHealth
 
 # All checks
 ./check

--- a/.docs/workflow/quality.md
+++ b/.docs/workflow/quality.md
@@ -69,13 +69,11 @@ Tests in `:konsist` module enforce patterns like:
 
 ## Dependency Analysis
 
-[DAGP](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) checks:
+[DAGP](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) is configured but its tasks
+(`buildHealth`, `projectHealth`) do not currently work with this project's KMP modules. Do not run them
+until they are validated against KMP.
 
-```bash
-./gradlew buildHealth
-```
-
-Verifies:
+When working, DAGP verifies:
 - Correct configurations (`implementation` vs `api`)
 - No unused dependencies
 - No transitive API leaks


### PR DESCRIPTION
## Summary
- DAGP's `buildHealth` and `projectHealth` tasks don't currently work with this project's KMP modules
- Updates agent rules (`.claude/rules/*`, `.claude/skills/check/SKILL.md`) and workflow docs (`.docs/workflow/*`) to flag the tasks as do-not-run for now
- The plugin itself remains configured so it can be re-enabled once KMP support is validated

Closes #296

## Test plan
- [ ] Docs render correctly (no broken markdown tables/links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)