### PR TITLE
#298 Add R8 -dontwarn rules for androidx.window extensions/sidecar

### DIFF
--- a/apps/android/proguard-rules.pro
+++ b/apps/android/proguard-rules.pro
@@ -54,3 +54,22 @@
 -keepclassmembers class * implements javax.net.ssl.X509TrustManager {
   public java.util.List checkServerTrusted(java.security.cert.X509Certificate[], java.lang.String, java.lang.String);
 }
+
+# https://issuetracker.google.com/issues/505815617
+-dontwarn androidx.test.platform.app.InstrumentationRegistry
+-dontwarn androidx.window.extensions.WindowExtensions
+-dontwarn androidx.window.extensions.WindowExtensionsProvider
+-dontwarn androidx.window.extensions.area.ExtensionWindowAreaPresentation
+-dontwarn androidx.window.extensions.core.util.function.Consumer
+-dontwarn androidx.window.extensions.core.util.function.Function
+-dontwarn androidx.window.extensions.core.util.function.Predicate
+-dontwarn androidx.window.extensions.layout.DisplayFeature
+-dontwarn androidx.window.extensions.layout.FoldingFeature
+-dontwarn androidx.window.extensions.layout.WindowLayoutComponent
+-dontwarn androidx.window.extensions.layout.WindowLayoutInfo
+-dontwarn androidx.window.sidecar.SidecarDeviceState
+-dontwarn androidx.window.sidecar.SidecarDisplayFeature
+-dontwarn androidx.window.sidecar.SidecarInterface$SidecarCallback
+-dontwarn androidx.window.sidecar.SidecarInterface
+-dontwarn androidx.window.sidecar.SidecarProvider
+-dontwarn androidx.window.sidecar.SidecarWindowLayoutInfo


### PR DESCRIPTION
## Summary
- Adds `-dontwarn` rules to `apps/android/proguard-rules.pro` for `androidx.window.extensions.*`, `androidx.window.sidecar.*`, and `androidx.test.platform.app.InstrumentationRegistry`
- These classes are referenced transitively by AndroidX but are platform/host-only at runtime, so R8 emits missing-class warnings during minified Android builds
- Tracked upstream at https://issuetracker.google.com/issues/505815617

Closes #298

## Test plan
- [ ] Minified Android build (`./gradlew :apps:android:assembleDevRelease` or equivalent) no longer surfaces missing-class warnings for the listed packages
- [ ] App still runs on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)