### PR TITLE
#270 Sort season episodes by index number and dedupe

### DIFF
--- a/data/items/public/src/commonMain/kotlin/com/eygraber/jellyfin/data/items/ItemSortBy.kt
+++ b/data/items/public/src/commonMain/kotlin/com/eygraber/jellyfin/data/items/ItemSortBy.kt
@@ -12,6 +12,17 @@ enum class ItemSortBy(val apiValue: String) {
   CommunityRating("CommunityRating"),
   Runtime("Runtime"),
   Random("Random"),
+
+  /**
+   * Sort by episode index within a season. Use [ParentIndexNumberThenIndexNumber]
+   * when listing episodes across multiple seasons.
+   */
+  IndexNumber("IndexNumber"),
+
+  /**
+   * Sort by season index then episode index. Useful for cross-season episode lists.
+   */
+  ParentIndexNumberThenIndexNumber("ParentIndexNumber,IndexNumber"),
 }
 
 /**

--- a/screens/tvshow-episodes/src/commonMain/kotlin/com/eygraber/jellyfin/screens/tvshow/episodes/model/TvShowEpisodesModel.kt
+++ b/screens/tvshow-episodes/src/commonMain/kotlin/com/eygraber/jellyfin/screens/tvshow/episodes/model/TvShowEpisodesModel.kt
@@ -47,14 +47,16 @@ class TvShowEpisodesModel(
     val result = itemsRepository.getItems(
       parentId = seasonId,
       includeItemTypes = listOf("Episode"),
-      sortBy = ItemSortBy.SortName,
+      sortBy = ItemSortBy.IndexNumber,
       sortOrder = SortOrder.Ascending,
       startIndex = 0,
       limit = MAX_EPISODES,
     )
 
     state = if(result.isSuccess()) {
-      val episodes = result.value.items.map { item -> item.toEpisodeItem() }
+      val episodes = result.value.items
+        .distinctBy { it.id }
+        .map { item -> item.toEpisodeItem() }
 
       TvShowEpisodesState(
         seasonName = seasonName,

--- a/screens/tvshow-episodes/src/commonTest/kotlin/com/eygraber/jellyfin/screens/tvshow/episodes/model/TvShowEpisodesModelTest.kt
+++ b/screens/tvshow-episodes/src/commonTest/kotlin/com/eygraber/jellyfin/screens/tvshow/episodes/model/TvShowEpisodesModelTest.kt
@@ -138,6 +138,51 @@ class TvShowEpisodesModelTest {
   }
 
   @Test
+  fun loadEpisodes_deduplicates_episodes_by_id() {
+    runTest {
+      fakeRepository.getItemResult = JellyfinResult.Success(
+        createLibraryItem(id = "season-1", name = "Season 1"),
+      )
+      fakeRepository.getItemsResult = JellyfinResult.Success(
+        PaginatedResult(
+          items = listOf(
+            createLibraryItem(id = "ep-1", name = "Pilot", indexNumber = 1),
+            createLibraryItem(id = "ep-2", name = "Episode Two", indexNumber = 2),
+            createLibraryItem(id = "ep-1", name = "Pilot (dup)", indexNumber = 1),
+          ),
+          totalRecordCount = 3,
+          startIndex = 0,
+        ),
+      )
+
+      model.loadEpisodes("season-1")
+
+      val state = model.stateForTest
+      state.episodes.size shouldBe 2
+      state.episodes[0].id shouldBe "ep-1"
+      state.episodes[0].name shouldBe "Pilot"
+      state.episodes[1].id shouldBe "ep-2"
+    }
+  }
+
+  @Test
+  fun loadEpisodes_uses_index_number_sort_order() {
+    runTest {
+      fakeRepository.getItemResult = JellyfinResult.Success(
+        createLibraryItem(id = "season-1", name = "Season 1"),
+      )
+      fakeRepository.getItemsResult = JellyfinResult.Success(
+        PaginatedResult(items = emptyList(), totalRecordCount = 0, startIndex = 0),
+      )
+
+      model.loadEpisodes("season-1")
+
+      fakeRepository.lastGetItemsSortBy shouldBe ItemSortBy.IndexNumber
+      fakeRepository.lastGetItemsSortOrder shouldBe SortOrder.Ascending
+    }
+  }
+
+  @Test
   fun episode_without_runtime_has_null_minutes() {
     runTest {
       fakeRepository.getItemResult = JellyfinResult.Success(
@@ -200,6 +245,9 @@ private class FakeItemsRepository : ItemsRepository {
 
   var getSimilarItemsResult: JellyfinResult<List<LibraryItem>> = JellyfinResult.Success(emptyList())
 
+  var lastGetItemsSortBy: ItemSortBy? = null
+  var lastGetItemsSortOrder: SortOrder? = null
+
   override suspend fun getItems(
     parentId: String,
     includeItemTypes: List<String>?,
@@ -211,7 +259,11 @@ private class FakeItemsRepository : ItemsRepository {
     years: List<Int>?,
     searchTerm: String?,
     fields: List<String>?,
-  ): JellyfinResult<PaginatedResult<LibraryItem>> = getItemsResult
+  ): JellyfinResult<PaginatedResult<LibraryItem>> {
+    lastGetItemsSortBy = sortBy
+    lastGetItemsSortOrder = sortOrder
+    return getItemsResult
+  }
 
   override suspend fun getItem(itemId: String): JellyfinResult<LibraryItem> = getItemResult
 


### PR DESCRIPTION
Closes #270

## Summary
- Episodes on the season detail screen were sorted by `SortName` (alphabetical) instead of episode number, leading to confusing ordering.
- The recursive `Items` query against a season's `parentId` can return the same episode through multiple metadata paths on some Jellyfin server layouts, causing visible duplicates.
- Added `ItemSortBy.IndexNumber` (and a `ParentIndexNumberThenIndexNumber` companion for cross-season lists) and used it for the season detail episode list, plus a `distinctBy { it.id }` guard in `TvShowEpisodesModel` so duplicates from the data layer can no longer leak into the UI.

Note: the "year as episode number" symptom in the original bug report could not be reproduced from the code path alone — the data layer maps `BaseItemDto.IndexNumber` -> `LibraryItem.indexNumber` -> `EpisodeItem.episodeNumber` correctly, with no `productionYear` involvement on the episodes screen. The sort + dedupe fix here addresses the duplicates and improves order; if the year issue persists for a given server it likely indicates server-side metadata (`IndexNumber` populated with the year) and warrants a separate report with sample data.

## Test plan
- [x] Unit tests for the new sort/dedupe behaviour (`TvShowEpisodesModelTest`)
- [ ] Manual: verify episodes appear in numeric order on the season detail screen
- [ ] Manual: verify no duplicate episode rows on libraries that previously showed them