### PR TITLE
#272 Auto-dismiss video player controls overlay after inactivity

### DIFF
--- a/screens/video-player/src/commonMain/kotlin/com/eygraber/jellyfin/screens/video/player/VideoPlayerCompositor.kt
+++ b/screens/video-player/src/commonMain/kotlin/com/eygraber/jellyfin/screens/video/player/VideoPlayerCompositor.kt
@@ -44,6 +44,20 @@ class VideoPlayerCompositor(
       }
     }
 
+    // Auto-dismiss the controls overlay after a period of inactivity while playing. Each
+    // user interaction bumps controlsInteractionEpoch in the model, which restarts this
+    // effect. The overlay never auto-dismisses while paused or while loading/buffering.
+    LaunchedEffect(
+      modelState.isControlsVisible,
+      modelState.controlsInteractionEpoch,
+      playerState.isPlaying,
+    ) {
+      if(modelState.isControlsVisible && playerState.isPlaying) {
+        delay(CONTROLS_AUTO_DISMISS_MS)
+        playerModel.hideControls()
+      }
+    }
+
     // Always release the underlying player when leaving composition, even if the user
     // navigated away via system back / gesture (which bypasses the NavigateBack intent and
     // therefore the suspending stop() call). The synchronous release matches ExoPlayer's
@@ -93,5 +107,6 @@ class VideoPlayerCompositor(
 
   companion object {
     private const val PROGRESS_REPORT_INTERVAL_MS = 10_000L
+    private const val CONTROLS_AUTO_DISMISS_MS = 4_000L
   }
 }

--- a/screens/video-player/src/commonMain/kotlin/com/eygraber/jellyfin/screens/video/player/model/VideoPlayerModel.kt
+++ b/screens/video-player/src/commonMain/kotlin/com/eygraber/jellyfin/screens/video/player/model/VideoPlayerModel.kt
@@ -18,6 +18,11 @@ data class VideoPlayerModelState(
   val playbackState: PlaybackState = PlaybackState.Idle,
   val isLoading: Boolean = true,
   val isControlsVisible: Boolean = true,
+  /**
+   * Increments whenever the user interacts with the controls overlay or the overlay is
+   * (re)shown. The compositor uses this as a key to restart its auto-dismiss timer.
+   */
+  val controlsInteractionEpoch: Int = 0,
   val error: VideoPlayerModelError? = null,
 )
 
@@ -85,18 +90,41 @@ class VideoPlayerModel(
 
   fun play() {
     playerService.play()
+    bumpControlsInteraction()
   }
 
   fun pause() {
     playerService.pause()
+    bumpControlsInteraction()
   }
 
   fun seekTo(positionMs: Long) {
     playerService.seekTo(positionMs)
+    bumpControlsInteraction()
   }
 
   fun toggleControls() {
-    state = state.copy(isControlsVisible = !state.isControlsVisible)
+    state = state.copy(
+      isControlsVisible = !state.isControlsVisible,
+      controlsInteractionEpoch = state.controlsInteractionEpoch + 1,
+    )
+  }
+
+  /**
+   * Hides the controls overlay. Used by the compositor's auto-dismiss timer.
+   */
+  fun hideControls() {
+    if(state.isControlsVisible) {
+      state = state.copy(isControlsVisible = false)
+    }
+  }
+
+  /**
+   * Resets the auto-dismiss timer without changing visibility. Called whenever the user
+   * interacts with the controls.
+   */
+  fun bumpControlsInteraction() {
+    state = state.copy(controlsInteractionEpoch = state.controlsInteractionEpoch + 1)
   }
 
   /**

--- a/screens/video-player/src/commonTest/kotlin/com/eygraber/jellyfin/screens/video/player/model/VideoPlayerModelTest.kt
+++ b/screens/video-player/src/commonTest/kotlin/com/eygraber/jellyfin/screens/video/player/model/VideoPlayerModelTest.kt
@@ -132,6 +132,58 @@ class VideoPlayerModelTest {
   }
 
   @Test
+  fun toggle_controls_bumps_interaction_epoch() {
+    val before = model.stateForTest.controlsInteractionEpoch
+
+    model.toggleControls()
+
+    model.stateForTest.controlsInteractionEpoch shouldBe before + 1
+  }
+
+  @Test
+  fun hide_controls_hides_overlay_without_bumping_epoch() {
+    model.stateForTest.isControlsVisible shouldBe true
+    val before = model.stateForTest.controlsInteractionEpoch
+
+    model.hideControls()
+
+    model.stateForTest.isControlsVisible shouldBe false
+    model.stateForTest.controlsInteractionEpoch shouldBe before
+  }
+
+  @Test
+  fun hide_controls_when_already_hidden_is_a_no_op() {
+    model.toggleControls()
+    model.stateForTest.isControlsVisible shouldBe false
+    val before = model.stateForTest.controlsInteractionEpoch
+
+    model.hideControls()
+
+    model.stateForTest.isControlsVisible shouldBe false
+    model.stateForTest.controlsInteractionEpoch shouldBe before
+  }
+
+  @Test
+  fun play_pause_seek_bump_interaction_epoch() {
+    val start = model.stateForTest.controlsInteractionEpoch
+
+    model.play()
+    model.pause()
+    model.seekTo(1_000L)
+
+    model.stateForTest.controlsInteractionEpoch shouldBe start + 3
+  }
+
+  @Test
+  fun bump_controls_interaction_increments_epoch() {
+    val before = model.stateForTest.controlsInteractionEpoch
+
+    model.bumpControlsInteraction()
+
+    model.stateForTest.controlsInteractionEpoch shouldBe before + 1
+  }
+
+  @Test
   fun stop_reports_stopped_and_releases_player() {
     runTest {
       fakeRepository.getPlaybackSessionResult = JellyfinResult.Success(createSession())


### PR DESCRIPTION
Closes #272

## Summary
- Controls overlay no longer stays up forever — it now fades out after four seconds of inactivity while playing.
- Tap-to-show, any control interaction (play, pause, seek), or a fresh `ToggleControls` resets the timer via a per-interaction epoch counter on the model state.
- The overlay stays visible while paused (or while loading/buffering means `isPlaying` is false), matching the typical player UX.

## Test plan
- [x] Unit tests cover hide/toggle visibility transitions and that interactions bump the epoch
- [ ] Manual: start playback, wait ~4s, confirm controls fade out
- [ ] Manual: tap to show controls, tap a button before timeout, confirm timer restarts
- [ ] Manual: pause playback, confirm controls remain visible indefinitely