### PR TITLE
#273 Keep session authenticated through transient validation failures

### DIFF
--- a/domain/session/impl/src/commonMain/kotlin/com/eygraber/jellyfin/domain/session/impl/DefaultSessionManager.kt
+++ b/domain/session/impl/src/commonMain/kotlin/com/eygraber/jellyfin/domain/session/impl/DefaultSessionManager.kt
@@ -1,12 +1,14 @@
 package com.eygraber.jellyfin.domain.session.impl
 
 import com.eygraber.jellyfin.common.JellyfinResult
+import com.eygraber.jellyfin.common.errorDetailOrNull
 import com.eygraber.jellyfin.common.isSuccess
 import com.eygraber.jellyfin.common.successOrNull
 import com.eygraber.jellyfin.data.auth.AuthRepository
 import com.eygraber.jellyfin.data.server.ServerRepository
 import com.eygraber.jellyfin.domain.session.SessionManager
 import com.eygraber.jellyfin.domain.session.SessionState
+import com.eygraber.jellyfin.sdk.core.JellyfinSdkError
 import com.eygraber.jellyfin.services.logging.JellyfinLogger
 import com.eygraber.jellyfin.services.sdk.JellyfinAuthService
 import com.eygraber.jellyfin.services.sdk.JellyfinSessionManager
@@ -90,28 +92,59 @@ internal class DefaultSessionManager(
       return state
     }
 
-    // Token is invalid/expired
-    logger.warn(tag = TAG, message = "Session token invalid for user: ${session.username}")
-    sdkSessionManager.clearAuthentication()
-    val state = SessionState.SessionExpired(session = session)
+    // The token check failed. Only treat unambiguous authentication failures (HTTP 401 or
+    // an explicit Authentication error from the SDK) as expiry — transient network errors,
+    // 5xx responses, etc. should leave the user authenticated so they aren't bounced to
+    // login every time the server is briefly unreachable.
+    if(userResult.isAuthenticationFailure()) {
+      logger.warn(tag = TAG, message = "Session token rejected by server for user: ${session.username}")
+      sdkSessionManager.clearAuthentication()
+      val state = SessionState.SessionExpired(session = session)
+      _sessionState.value = state
+      return state
+    }
+
+    logger.warn(
+      tag = TAG,
+      message = "Session validation could not reach server; keeping cached session for user: ${session.username}",
+    )
+    val state = SessionState.Authenticated(session = session)
     _sessionState.value = state
     return state
   }
 
+  @Suppress("ReturnCount")
   override suspend fun validateSession(): Boolean {
     val current = _sessionState.value
     if(current !is SessionState.Authenticated) {
       return false
     }
 
-    val isValid = authService.getCurrentUser().isSuccess()
-    if(!isValid) {
-      logger.warn(tag = TAG, message = "Session validation failed")
-      sdkSessionManager.clearAuthentication()
-      _sessionState.value = SessionState.SessionExpired(session = current.session)
+    val result = authService.getCurrentUser()
+    if(result.isSuccess()) {
+      return true
     }
 
-    return isValid
+    if(result.isAuthenticationFailure()) {
+      logger.warn(tag = TAG, message = "Session validation failed: token rejected")
+      sdkSessionManager.clearAuthentication()
+      _sessionState.value = SessionState.SessionExpired(session = current.session)
+      return false
+    }
+
+    // Transient failure (network, 5xx, etc.) — keep the session authenticated and let the
+    // caller surface whatever load error they got from their own API call.
+    logger.warn(tag = TAG, message = "Session validation could not reach server; keeping session")
+    return true
+  }
+
+  private fun JellyfinResult<*>.isAuthenticationFailure(): Boolean {
+    if(this !is JellyfinResult.Error) return false
+    return when(val detail = errorDetailOrNull) {
+      is JellyfinSdkError.Authentication -> true
+      is JellyfinSdkError.Http -> detail.statusCode == HTTP_UNAUTHORIZED
+      else -> false
+    }
   }
 
   override suspend fun onLoginSuccess(
@@ -155,5 +188,6 @@ internal class DefaultSessionManager(
 
   companion object {
     private const val TAG = "SessionManager"
+    private const val HTTP_UNAUTHORIZED = 401
   }
 }

--- a/domain/session/impl/src/commonTest/kotlin/com/eygraber/jellyfin/domain/session/impl/DefaultSessionManagerTest.kt
+++ b/domain/session/impl/src/commonTest/kotlin/com/eygraber/jellyfin/domain/session/impl/DefaultSessionManagerTest.kt
@@ -10,6 +10,7 @@ import com.eygraber.jellyfin.data.auth.UserSessionEntity
 import com.eygraber.jellyfin.data.server.ServerEntity
 import com.eygraber.jellyfin.data.server.ServerRepository
 import com.eygraber.jellyfin.domain.session.SessionState
+import com.eygraber.jellyfin.sdk.core.JellyfinSdkError
 import com.eygraber.jellyfin.sdk.core.ServerInfo
 import com.eygraber.jellyfin.sdk.core.model.AuthenticationResult
 import com.eygraber.jellyfin.sdk.core.model.UserDto
@@ -105,16 +106,40 @@ class DefaultSessionManagerTest {
     runTest {
       fakeAuthRepository.activeSession = testSession
       fakeServerRepository.servers["server-1"] = testServer
-      fakeAuthService.currentUserResult = JellyfinResult.Error(
-        message = "Unauthorized",
-        isEphemeral = false,
-      )
+      fakeAuthService.currentUserResult = unauthorizedError()
 
       val result = sessionManager.restoreSession()
 
       result.shouldBeInstanceOf<SessionState.SessionExpired>()
       result.session.userId shouldBe "user-1"
       sessionManager.sessionState.value.shouldBeInstanceOf<SessionState.SessionExpired>()
+    }
+  }
+
+  @Test
+  fun restore_session_keeps_authenticated_on_transient_failure() {
+    runTest {
+      fakeAuthRepository.activeSession = testSession
+      fakeServerRepository.servers["server-1"] = testServer
+      fakeAuthService.currentUserResult = networkError()
+
+      val result = sessionManager.restoreSession()
+
+      result.shouldBeInstanceOf<SessionState.Authenticated>()
+      sessionManager.sessionState.value.shouldBeInstanceOf<SessionState.Authenticated>()
+    }
+  }
+
+  @Test
+  fun restore_session_keeps_authenticated_on_5xx_error() {
+    runTest {
+      fakeAuthRepository.activeSession = testSession
+      fakeServerRepository.servers["server-1"] = testServer
+      fakeAuthService.currentUserResult = httpError(statusCode = 503)
+
+      val result = sessionManager.restoreSession()
+
+      result.shouldBeInstanceOf<SessionState.Authenticated>()
     }
   }
 
@@ -176,15 +201,31 @@ class DefaultSessionManagerTest {
       )
       sessionManager.restoreSession()
 
-      // Then make validate fail
-      fakeAuthService.currentUserResult = JellyfinResult.Error(
-        message = "Token expired",
-        isEphemeral = false,
-      )
+      // Then make validate fail with a true 401
+      fakeAuthService.currentUserResult = unauthorizedError()
       val isValid = sessionManager.validateSession()
 
       isValid shouldBe false
       sessionManager.sessionState.value.shouldBeInstanceOf<SessionState.SessionExpired>()
+    }
+  }
+
+  @Test
+  fun validate_session_stays_authenticated_on_transient_failure() {
+    runTest {
+      fakeAuthRepository.activeSession = testSession
+      fakeServerRepository.servers["server-1"] = testServer
+
+      fakeAuthService.currentUserResult = JellyfinResult.Success(
+        UserDto(id = "user-1", name = "testuser"),
+      )
+      sessionManager.restoreSession()
+
+      fakeAuthService.currentUserResult = networkError()
+      val isValid = sessionManager.validateSession()
+
+      isValid shouldBe true
+      sessionManager.sessionState.value.shouldBeInstanceOf<SessionState.Authenticated>()
     }
   }
 
@@ -221,6 +262,24 @@ class DefaultSessionManagerTest {
       sessionManager.sessionState.value.shouldBeInstanceOf<SessionState.Authenticated>()
     }
   }
+
+  private fun unauthorizedError(): JellyfinResult<UserDto> = JellyfinResult.Error.Detailed(
+    details = JellyfinSdkError.Http(statusCode = 401, message = "Unauthorized"),
+    message = "Unauthorized",
+    isEphemeral = false,
+  )
+
+  private fun networkError(): JellyfinResult<UserDto> = JellyfinResult.Error.Detailed(
+    details = JellyfinSdkError.Network(cause = RuntimeException("connection failed")),
+    message = "connection failed",
+    isEphemeral = true,
+  )
+
+  private fun httpError(statusCode: Int): JellyfinResult<UserDto> = JellyfinResult.Error.Detailed(
+    details = JellyfinSdkError.Http(statusCode = statusCode, message = "Server error"),
+    message = "Server error",
+    isEphemeral = statusCode in 500..599,
+  )
 
   @Test
   fun session_state_flow_emits_transitions() {


### PR DESCRIPTION
Closes #273

## Summary
- Sessions were being bounced back to the login screen on **any** failure of `getCurrentUser()` — including transient network errors and 5xx responses, which is almost certainly the "expires quickly" symptom users were seeing.
- `restoreSession()` and `validateSession()` now only treat true authentication failures (HTTP 401 or `JellyfinSdkError.Authentication`) as session-expired. For network errors, serialization errors, and 5xx responses they keep the cached session and let the caller surface a plain "couldn't reach server" error from their own API call.
- This matches Jellyfin's own behaviour: access tokens are long-lived (no expiry by default), so the only legitimate signal that a token is "no longer good" is a 401 from the server.

## Test plan
- [x] Unit tests for restore/validate covering: success, 401 expiry, network failure, 5xx
- [ ] Manual: turn wifi off briefly, refresh home, confirm user is not bounced to login
- [ ] Manual: revoke the device token in Jellyfin's dashboard, refresh, confirm user is moved to login