### PR TITLE
#274 Use side-by-side layout for show details on expanded windows

### DIFF
--- a/screens/tvshow-detail/build.gradle.kts
+++ b/screens/tvshow-detail/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
       implementation(libs.compose.foundation)
       implementation(libs.compose.foundationLayout)
       implementation(libs.compose.material3)
+      implementation(libs.compose.material3.adaptiveNavigationSuite)
       implementation(libs.compose.nav3.runtime)
       implementation(libs.compose.runtime)
       implementation(libs.compose.runtimeAnnotation)

--- a/screens/tvshow-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/tvshow/detail/TvShowDetailView.kt
+++ b/screens/tvshow-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/tvshow/detail/TvShowDetailView.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -32,6 +31,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
 import com.eygraber.jellyfin.ui.compose.PreviewJellyfinScreen
 import com.eygraber.jellyfin.ui.icons.ArrowBack
 import com.eygraber.jellyfin.ui.icons.JellyfinIcons
@@ -55,7 +56,6 @@ internal typealias TvShowDetailView = ViceView<TvShowDetailIntent, TvShowDetailV
 private const val BACKDROP_ASPECT_RATIO = 16F / 9F
 private const val SEASON_POSTER_ASPECT_RATIO = 2F / 3F
 private const val RATING_DECIMAL_FACTOR = 10
-private val expandedWidthBreakpoint = 840.dp
 private val expandedBackdropMaxWidth = 640.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -111,22 +111,20 @@ private fun ShowContent(
   seasons: List<TvShowSeasonSummary>,
   onSeasonClick: (seasonId: String) -> Unit,
 ) {
-  BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-    val isExpanded = maxWidth >= expandedWidthBreakpoint
-    if(isExpanded) {
-      ExpandedShowContent(
-        show = show,
-        seasons = seasons,
-        onSeasonClick = onSeasonClick,
-      )
-    }
-    else {
-      CompactShowContent(
-        show = show,
-        seasons = seasons,
-        onSeasonClick = onSeasonClick,
-      )
-    }
+  val sizeClass = currentWindowAdaptiveInfo().windowSizeClass
+  if(sizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)) {
+    ExpandedShowContent(
+      show = show,
+      seasons = seasons,
+      onSeasonClick = onSeasonClick,
+    )
+  }
+  else {
+    CompactShowContent(
+      show = show,
+      seasons = seasons,
+      onSeasonClick = onSeasonClick,
+    )
   }
 }
 
@@ -313,11 +311,10 @@ private fun BackdropSection(
         .fillMaxSize()
         .background(
           Brush.verticalGradient(
-            colors = listOf(
-              Color.Transparent,
-              MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+            colorStops = arrayOf(
+              0.5f to Color.Transparent,
+              1f to MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
             ),
-            startY = Float.POSITIVE_INFINITY / 2,
           ),
         ),
     )

--- a/screens/tvshow-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/tvshow/detail/TvShowDetailView.kt
+++ b/screens/tvshow-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/tvshow/detail/TvShowDetailView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -53,6 +55,8 @@ internal typealias TvShowDetailView = ViceView<TvShowDetailIntent, TvShowDetailV
 private const val BACKDROP_ASPECT_RATIO = 16F / 9F
 private const val SEASON_POSTER_ASPECT_RATIO = 2F / 3F
 private const val RATING_DECIMAL_FACTOR = 10
+private val expandedWidthBreakpoint = 840.dp
+private val expandedBackdropMaxWidth = 640.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -107,6 +111,31 @@ private fun ShowContent(
   seasons: List<TvShowSeasonSummary>,
   onSeasonClick: (seasonId: String) -> Unit,
 ) {
+  BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    val isExpanded = maxWidth >= expandedWidthBreakpoint
+    if(isExpanded) {
+      ExpandedShowContent(
+        show = show,
+        seasons = seasons,
+        onSeasonClick = onSeasonClick,
+      )
+    }
+    else {
+      CompactShowContent(
+        show = show,
+        seasons = seasons,
+        onSeasonClick = onSeasonClick,
+      )
+    }
+  }
+}
+
+@Composable
+private fun CompactShowContent(
+  show: TvShowDetail,
+  seasons: List<TvShowSeasonSummary>,
+  onSeasonClick: (seasonId: String) -> Unit,
+) {
   Column(
     modifier = Modifier
       .fillMaxSize()
@@ -114,53 +143,10 @@ private fun ShowContent(
   ) {
     BackdropSection(show = show)
 
-    Column(
-      modifier = Modifier.padding(horizontal = 16.dp),
-    ) {
-      Spacer(modifier = Modifier.height(16.dp))
-
-      Text(
-        text = show.name,
-        style = MaterialTheme.typography.headlineMedium,
-        fontWeight = FontWeight.Bold,
-      )
-
-      Spacer(modifier = Modifier.height(8.dp))
-
-      MetadataRow(show = show)
-
-      show.overview?.let { overview ->
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Text(
-          text = "Overview",
-          style = MaterialTheme.typography.titleMedium,
-          fontWeight = FontWeight.SemiBold,
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-          text = overview,
-          style = MaterialTheme.typography.bodyMedium,
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-      }
-    }
+    ShowMetaSection(show = show)
 
     if(seasons.isNotEmpty()) {
-      Spacer(modifier = Modifier.height(24.dp))
-
-      Text(
-        text = "Seasons",
-        style = MaterialTheme.typography.titleMedium,
-        fontWeight = FontWeight.SemiBold,
-        modifier = Modifier.padding(horizontal = 16.dp),
-      )
-
-      Spacer(modifier = Modifier.height(8.dp))
-
-      SeasonsRow(
+      SeasonsSection(
         seasons = seasons,
         onSeasonClick = onSeasonClick,
       )
@@ -171,11 +157,141 @@ private fun ShowContent(
 }
 
 @Composable
-private fun BackdropSection(
+private fun ExpandedShowContent(
+  show: TvShowDetail,
+  seasons: List<TvShowSeasonSummary>,
+  onSeasonClick: (seasonId: String) -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState()),
+  ) {
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 24.dp, vertical = 16.dp),
+      horizontalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+      BackdropSection(
+        show = show,
+        modifier = Modifier
+          .weight(1f)
+          .widthIn(max = expandedBackdropMaxWidth),
+      )
+
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          text = show.name,
+          style = MaterialTheme.typography.headlineMedium,
+          fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        MetadataRow(show = show)
+
+        show.overview?.let { overview ->
+          Spacer(modifier = Modifier.height(16.dp))
+
+          Text(
+            text = "Overview",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+          )
+
+          Spacer(modifier = Modifier.height(8.dp))
+
+          Text(
+            text = overview,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+    }
+
+    if(seasons.isNotEmpty()) {
+      SeasonsSection(
+        seasons = seasons,
+        onSeasonClick = onSeasonClick,
+      )
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
+  }
+}
+
+@Composable
+private fun ShowMetaSection(
   show: TvShowDetail,
 ) {
+  Column(
+    modifier = Modifier.padding(horizontal = 16.dp),
+  ) {
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+      text = show.name,
+      style = MaterialTheme.typography.headlineMedium,
+      fontWeight = FontWeight.Bold,
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    MetadataRow(show = show)
+
+    show.overview?.let { overview ->
+      Spacer(modifier = Modifier.height(16.dp))
+
+      Text(
+        text = "Overview",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+      )
+
+      Spacer(modifier = Modifier.height(8.dp))
+
+      Text(
+        text = overview,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+  }
+}
+
+@Composable
+private fun SeasonsSection(
+  seasons: List<TvShowSeasonSummary>,
+  onSeasonClick: (seasonId: String) -> Unit,
+) {
+  Column {
+    Spacer(modifier = Modifier.height(24.dp))
+
+    Text(
+      text = "Seasons",
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.SemiBold,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    SeasonsRow(
+      seasons = seasons,
+      onSeasonClick = onSeasonClick,
+    )
+  }
+}
+
+@Composable
+private fun BackdropSection(
+  show: TvShowDetail,
+  modifier: Modifier = Modifier,
+) {
   Box(
-    modifier = Modifier
+    modifier = modifier
       .fillMaxWidth()
       .aspectRatio(BACKDROP_ASPECT_RATIO),
   ) {


### PR DESCRIPTION
Closes #274

## Summary
- The show detail screen rendered a 16:9 backdrop at the full viewport width, which on a desktop / wide layout completely filled the visible area with no hint that the overview, metadata, and seasons row scrolled below.
- `ShowContent` now wraps in `BoxWithConstraints` and picks a layout per the project's adaptive breakpoints:
  - Compact (< 840dp width): unchanged stack — full-width backdrop, then text, then seasons row.
  - Expanded (>= 840dp width): backdrop and text sit side-by-side with the backdrop capped at 640dp wide, so the overview is visible above the fold and the seasons row scrolls in clearly below.

## Test plan
- [x] Compose / detekt / lint all green
- [ ] Manual: shrink the desktop window to under 840dp, confirm the original stacked layout returns
- [ ] Manual: open show detail on desktop / iPad-class window, confirm backdrop and text render side-by-side and seasons row is visible/scroll-hinted