### PR TITLE
#276 Reserve fixed metadata lines for uniform card heights

### DIFF
--- a/screens/collection-items/src/commonMain/kotlin/com/eygraber/jellyfin/screens/collection/items/components/CollectionItemsGrid.kt
+++ b/screens/collection-items/src/commonMain/kotlin/com/eygraber/jellyfin/screens/collection/items/components/CollectionItemsGrid.kt
@@ -123,13 +123,13 @@ private fun ContentItemCard(
           overflow = TextOverflow.Ellipsis,
         )
 
-        item.productionYear?.let { year ->
-          Text(
-            text = year.toString(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
+        // Reserve a fixed line for the year so cards stay the same height regardless of metadata.
+        Text(
+          text = item.productionYear?.toString() ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+        )
       }
     }
   }

--- a/screens/genre-items/src/commonMain/kotlin/com/eygraber/jellyfin/screens/genre/items/components/GenreItemsGrid.kt
+++ b/screens/genre-items/src/commonMain/kotlin/com/eygraber/jellyfin/screens/genre/items/components/GenreItemsGrid.kt
@@ -123,13 +123,13 @@ private fun GenreContentItemCard(
           overflow = TextOverflow.Ellipsis,
         )
 
-        item.productionYear?.let { year ->
-          Text(
-            text = year.toString(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
+        // Reserve a fixed line for the year so cards stay the same height regardless of metadata.
+        Text(
+          text = item.productionYear?.toString() ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+        )
       }
     }
   }

--- a/screens/library-collections/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/collections/components/CollectionPosterGrid.kt
+++ b/screens/library-collections/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/collections/components/CollectionPosterGrid.kt
@@ -123,13 +123,13 @@ private fun CollectionCard(
           overflow = TextOverflow.Ellipsis,
         )
 
-        collection.itemCount?.let { count ->
-          Text(
-            text = "$count items",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
+        // Reserve a fixed line for the item count so cards stay the same height regardless of metadata.
+        Text(
+          text = collection.itemCount?.let { count -> "$count items" } ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+        )
       }
     }
   }

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/components/MoviePosterGrid.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/components/MoviePosterGrid.kt
@@ -36,6 +36,7 @@ import kotlin.math.roundToInt
 private const val POSTER_ASPECT_RATIO = 2F / 3F
 private const val LOAD_MORE_THRESHOLD = 10
 private const val RATING_DECIMAL_FACTOR = 10
+private const val TITLE_LINES = 2
 
 @Composable
 internal fun MoviePosterGrid(
@@ -131,28 +132,28 @@ private fun MoviePosterCard(
         Text(
           text = movie.name,
           style = MaterialTheme.typography.bodySmall,
-          maxLines = 2,
+          minLines = TITLE_LINES,
+          maxLines = TITLE_LINES,
           overflow = TextOverflow.Ellipsis,
         )
 
-        val yearText = movie.productionYear?.toString().orEmpty()
-        if(yearText.isNotEmpty()) {
-          Text(
-            text = yearText,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
+        // Reserve a fixed line for the year so cards stay the same height regardless of metadata.
+        Text(
+          text = movie.productionYear?.toString() ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+        )
 
-        movie.communityRating?.let { rating ->
-          Text(
-            text = rating.formatRating(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.primary,
-            textAlign = TextAlign.End,
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
+        // Reserve a fixed line for the rating so cards stay the same height regardless of metadata.
+        Text(
+          text = movie.communityRating?.formatRating() ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.primary,
+          textAlign = TextAlign.End,
+          maxLines = 1,
+          modifier = Modifier.fillMaxWidth(),
+        )
       }
     }
   }

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/components/AlbumsGrid.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/components/AlbumsGrid.kt
@@ -131,23 +131,22 @@ private fun AlbumCard(
           overflow = TextOverflow.Ellipsis,
         )
 
-        album.artistName?.let { artist ->
-          Text(
-            text = artist,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-          )
-        }
+        // Reserve a fixed line for the artist so cards stay the same height regardless of metadata.
+        Text(
+          text = album.artistName ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
 
-        album.productionYear?.let { year ->
-          Text(
-            text = year.toString(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
+        // Reserve a fixed line for the year so cards stay the same height regardless of metadata.
+        Text(
+          text = album.productionYear?.toString() ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+        )
       }
     }
   }

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/components/TvShowPosterGrid.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/components/TvShowPosterGrid.kt
@@ -33,6 +33,7 @@ import com.eygraber.jellyfin.ui.material.image.JellyfinAsyncImage
 
 private const val POSTER_ASPECT_RATIO = 2F / 3F
 private const val LOAD_MORE_THRESHOLD = 10
+private const val TITLE_LINES = 2
 
 @Composable
 internal fun TvShowPosterGrid(
@@ -128,26 +129,26 @@ private fun TvShowPosterCard(
         Text(
           text = show.name,
           style = MaterialTheme.typography.bodySmall,
-          maxLines = 2,
+          minLines = TITLE_LINES,
+          maxLines = TITLE_LINES,
           overflow = TextOverflow.Ellipsis,
         )
 
-        val yearText = show.productionYear?.toString().orEmpty()
-        if(yearText.isNotEmpty()) {
-          Text(
-            text = yearText,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
+        // Reserve a fixed line for the year so cards stay the same height regardless of metadata.
+        Text(
+          text = show.productionYear?.toString() ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+        )
 
-        show.seasonCount?.let { count ->
-          Text(
-            text = "$count season${if(count != 1) "s" else ""}",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.primary,
-          )
-        }
+        // Reserve a fixed line for the season count so cards stay the same height regardless of metadata.
+        Text(
+          text = show.seasonCount?.let { count -> "$count season${if(count != 1) "s" else ""}" } ?: " ",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.primary,
+          maxLines = 1,
+        )
       }
     }
   }

--- a/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/components/ArtistAlbumsGrid.kt
+++ b/screens/music-artist-albums/src/commonMain/kotlin/com/eygraber/jellyfin/screens/music/artist/albums/components/ArtistAlbumsGrid.kt
@@ -100,13 +100,14 @@ private fun ArtistAlbumCard(
           album.trackCount?.let { "$it tracks" },
         ).joinToString(" \u00B7 ")
 
-        if(details.isNotEmpty()) {
-          Text(
-            text = details,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
+        // Reserve a fixed line for the metadata so cards stay the same height regardless of content.
+        Text(
+          text = details.ifEmpty { " " },
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
       }
     }
   }


### PR DESCRIPTION
Closes #276

## Summary

- Each library/category card composable was producing variable-height cards because:
  - Movies/TvShows posters had `maxLines = 2` titles (so single-line titles took less vertical space than two-line ones).
  - All cards rendered secondary metadata (year, rating, season count, item count, artist, etc.) conditionally, so cards missing a field were shorter than their neighbors.
- Each card now:
  - Pins the title with `minLines = maxLines` so the title block always reserves the same number of lines.
  - Replaces conditional secondary `Text`s with always-rendered placeholders (a single space when the value is absent), so every card slot is the same height regardless of which metadata is present.
- Touched grids: Movies, TvShows, Music (Albums), Collections, Genre Items, Collection Items, Artist Albums.

## Test plan

- [ ] Open Movies library — cards in the same row are now the same height regardless of title length / missing year / missing rating.
- [ ] Open TvShows library — same uniform heights with optional year / season count.
- [ ] Open Music library — album cards uniform with/without artist or year.
- [ ] Open Collections library — uniform heights with/without item count.
- [ ] Open a Genre's items page — uniform with/without year.
- [ ] Open a Collection's items page — uniform with/without year.
- [ ] Open an Artist's albums page — uniform with/without metadata.