### PR TITLE
#277 Collapse movie cast/crew duplicates into one card per person

### DIFF
--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailView.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/MovieDetailView.kt
@@ -414,12 +414,12 @@ private fun PersonCard(
     )
 
     subtitle?.let { subtitleText ->
+      // Each distinct role/job is on its own line (joined with '\n' in the model). Render all
+      // lines so users can see every credit, matching the official Jellyfin web layout.
       Text(
         text = subtitleText,
         style = MaterialTheme.typography.labelSmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
         textAlign = TextAlign.Center,
       )
     }

--- a/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/model/MovieDetailModel.kt
+++ b/screens/movie-detail/src/commonMain/kotlin/com/eygraber/jellyfin/screens/movie/detail/model/MovieDetailModel.kt
@@ -50,12 +50,17 @@ class MovieDetailModel(
     if(result.isSuccess()) {
       val item = result.value
       val movieDetail = item.toMovieDetail()
+      // Jellyfin's people array can list the same person multiple times — most commonly a crew
+      // member credited under several jobs, but also actors with multiple roles. Collapse to one
+      // entry per person, joining all of their distinct roles/jobs into the displayed subtitle.
       val cast = item.people
         .filter { it.type == PERSON_TYPE_ACTOR }
-        .map { it.toCastMember() }
+        .groupBy { it.id }
+        .map { (_, credits) -> credits.toCastMember() }
       val crew = item.people
         .filter { it.type != PERSON_TYPE_ACTOR }
-        .map { it.toCrewMember() }
+        .groupBy { it.id }
+        .map { (_, credits) -> credits.toCrewMember() }
 
       state = MovieDetailState(
         movie = movieDetail,
@@ -113,33 +118,41 @@ class MovieDetailModel(
     },
   )
 
-  private fun PersonItem.toCastMember(): CastMember = CastMember(
-    id = id,
-    name = name,
-    role = role,
-    imageUrl = primaryImageTag?.let { tag ->
-      libraryService.getImageUrl(
-        itemId = id,
-        imageType = ImageType.Primary,
-        maxWidth = PERSON_IMAGE_MAX_WIDTH,
-        tag = tag,
-      )
-    },
-  )
+  private fun List<PersonItem>.toCastMember(): CastMember {
+    val canonical = first()
+    return CastMember(
+      id = canonical.id,
+      name = canonical.name,
+      role = combinedRoles(),
+      imageUrl = canonical.personImageUrl(),
+    )
+  }
 
-  private fun PersonItem.toCrewMember(): CrewMember = CrewMember(
-    id = id,
-    name = name,
-    job = role,
-    imageUrl = primaryImageTag?.let { tag ->
-      libraryService.getImageUrl(
-        itemId = id,
-        imageType = ImageType.Primary,
-        maxWidth = PERSON_IMAGE_MAX_WIDTH,
-        tag = tag,
-      )
-    },
-  )
+  private fun List<PersonItem>.toCrewMember(): CrewMember {
+    val canonical = first()
+    return CrewMember(
+      id = canonical.id,
+      name = canonical.name,
+      job = combinedRoles(),
+      imageUrl = canonical.personImageUrl(),
+    )
+  }
+
+  // Each distinct role/job goes on its own line, matching the official Jellyfin web layout.
+  private fun List<PersonItem>.combinedRoles(): String? = asSequence()
+    .mapNotNull { it.role?.takeIf(String::isNotBlank) }
+    .distinct()
+    .joinToString("\n")
+    .takeIf(String::isNotEmpty)
+
+  private fun PersonItem.personImageUrl(): String? = primaryImageTag?.let { tag ->
+    libraryService.getImageUrl(
+      itemId = id,
+      imageType = ImageType.Primary,
+      maxWidth = PERSON_IMAGE_MAX_WIDTH,
+      tag = tag,
+    )
+  }
 
   private fun LibraryItem.toSimilarItem(): SimilarItem = SimilarItem(
     id = id,

--- a/screens/movie-detail/src/commonTest/kotlin/com/eygraber/jellyfin/screens/movie/detail/model/MovieDetailModelTest.kt
+++ b/screens/movie-detail/src/commonTest/kotlin/com/eygraber/jellyfin/screens/movie/detail/model/MovieDetailModelTest.kt
@@ -240,6 +240,79 @@ class MovieDetailModelTest {
   }
 
   @Test
+  fun loadMovie_collapses_cast_with_multiple_roles_into_one_entry() {
+    runTest {
+      fakeRepository.getItemResult = JellyfinResult.Success(
+        createLibraryItem(
+          id = "movie-1",
+          name = "Movie",
+          people = listOf(
+            PersonItem(id = "p1", name = "Actor One", role = "Lead", type = "Actor", primaryImageTag = null),
+            PersonItem(id = "p1", name = "Actor One", role = "Lead", type = "Actor", primaryImageTag = null),
+            PersonItem(id = "p1", name = "Actor One", role = "Cameo", type = "Actor", primaryImageTag = null),
+          ),
+        ),
+      )
+
+      model.loadMovie(movieId = "movie-1")
+
+      val cast = model.stateForTest.cast
+      cast shouldHaveSize 1
+      cast[0].id shouldBe "p1"
+      cast[0].name shouldBe "Actor One"
+      cast[0].role shouldBe "Lead\nCameo"
+    }
+  }
+
+  @Test
+  fun loadMovie_collapses_crew_with_multiple_jobs_into_one_entry() {
+    runTest {
+      fakeRepository.getItemResult = JellyfinResult.Success(
+        createLibraryItem(
+          id = "movie-1",
+          name = "Movie",
+          people = listOf(
+            PersonItem(id = "p1", name = "Person", role = "Director", type = "Director", primaryImageTag = null),
+            PersonItem(id = "p1", name = "Person", role = "Director", type = "Director", primaryImageTag = null),
+            PersonItem(id = "p1", name = "Person", role = "Producer", type = "Producer", primaryImageTag = null),
+            PersonItem(id = "p1", name = "Person", role = "Writer", type = "Writer", primaryImageTag = null),
+          ),
+        ),
+      )
+
+      model.loadMovie(movieId = "movie-1")
+
+      val crew = model.stateForTest.crew
+      crew shouldHaveSize 1
+      crew[0].id shouldBe "p1"
+      crew[0].name shouldBe "Person"
+      crew[0].job shouldBe "Director\nProducer\nWriter"
+    }
+  }
+
+  @Test
+  fun loadMovie_crew_entry_has_null_job_when_all_roles_blank() {
+    runTest {
+      fakeRepository.getItemResult = JellyfinResult.Success(
+        createLibraryItem(
+          id = "movie-1",
+          name = "Movie",
+          people = listOf(
+            PersonItem(id = "p1", name = "Person", role = null, type = "Director", primaryImageTag = null),
+            PersonItem(id = "p1", name = "Person", role = "", type = "Director", primaryImageTag = null),
+          ),
+        ),
+      )
+
+      model.loadMovie(movieId = "movie-1")
+
+      val crew = model.stateForTest.crew
+      crew shouldHaveSize 1
+      crew[0].job.shouldBeNull()
+    }
+  }
+
+  @Test
   fun loadMovie_loads_similar_items() {
     runTest {
       fakeRepository.getItemResult = JellyfinResult.Success(


### PR DESCRIPTION
Closes #277

## Summary

- Fixes the duplicate-key `LazyList` crash that fired the moment the movie detail screen was measured after selecting a movie. Confirmed exclusive to Movies — TV show / episode detail screens don't render a people list.
- Root cause: Jellyfin's `people` array commonly lists the same person multiple times. Crew members credited under several jobs (Director + Writer + Producer is routine) and occasionally actors with more than one role both produce repeated `id`s. The `CastRow` / `CrewRow` lazy lists keyed by `{ it.id }`, so the second occurrence crashed the lazy layout with `Key "<id>" was already used`.
- UX: collapse to a single card per person and put each distinct role / job on its own line under the person's name — matching the official Jellyfin web layout (e.g. `Adam Sandler` / `Writer` / `Screenplay`). Keys in the view return to plain `it.id` since each row is now unique by person, and the subtitle no longer truncates.

## Test plan

- [x] Existing `MovieDetailModelTest` cases still pass (cast extraction, crew extraction, similar items, error/retry paths).
- [x] New `MovieDetailModelTest` cases cover collapsed-into-one-entry behaviour with newline-separated credits, plus the all-blank-roles edge case.
- [ ] Manual verification on Desktop: open a movie whose crew has the same person under multiple jobs (the case that originally crashed) — confirm no crash and that the person appears once with each credit on its own line, center-aligned.