### PR TITLE
#275 Persist category sort/filter across forward+back navigation

### DIFF
--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryCompositor.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryCompositor.kt
@@ -7,10 +7,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.screens.library.movies.model.MoviesLibraryModel
 import com.eygraber.jellyfin.screens.library.movies.model.MoviesLibraryModelError
+import com.eygraber.jellyfin.ui.library.controls.LibraryFilters
 import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
 import com.eygraber.jellyfin.ui.library.controls.LibraryViewMode
+import com.eygraber.jellyfin.ui.library.controls.rememberLibraryFilters
+import com.eygraber.jellyfin.ui.library.controls.rememberLibrarySortConfig
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.channels.Channel
 
 @Inject
 class MoviesLibraryCompositor(
@@ -21,13 +25,38 @@ class MoviesLibraryCompositor(
   private var isFilterSheetVisible by mutableStateOf(false)
   private var viewMode by mutableStateOf(LibraryViewMode.Grid)
 
+  // Sort/filter live in `composite()` via rememberSaveable so they survive composition disposal
+  // when the user navigates into an item and back. `onIntent` writes through these channels and
+  // the drain coroutines update the saved state inside the composition.
+  private val sortMutations = Channel<LibrarySortConfig>(Channel.CONFLATED)
+  private val filterMutations = Channel<LibraryFilters>(Channel.CONFLATED)
+
+  // Plain mirrors of the latest sort/filter, kept in sync from within `composite()` so non-Compose
+  // callers (Refresh / RetryLoad / LoadMore intents) can read the current values without observers.
+  @Volatile private var currentSortConfig: LibrarySortConfig = LibrarySortConfig()
+  @Volatile private var currentFilters: LibraryFilters = LibraryFilters()
+
   @Composable
   override fun composite(): MoviesLibraryViewState {
+    var sortConfig by rememberLibrarySortConfig()
+    var filters by rememberLibraryFilters()
+
+    LaunchedEffect(Unit) {
+      for(next in sortMutations) sortConfig = next
+    }
+    LaunchedEffect(Unit) {
+      for(next in filterMutations) filters = next
+    }
+
     val modelState = moviesModel.currentState()
 
     LaunchedEffect(Unit) {
-      moviesModel.loadInitial(key.libraryId)
       moviesModel.loadAvailableFilters(key.libraryId)
+    }
+    LaunchedEffect(sortConfig, filters) {
+      currentSortConfig = sortConfig
+      currentFilters = filters
+      moviesModel.loadInitial(key.libraryId, sortConfig, filters)
     }
 
     return MoviesLibraryViewState(
@@ -37,8 +66,8 @@ class MoviesLibraryCompositor(
       error = modelState.error?.toViewError(),
       hasMore = modelState.hasMore,
       isEmpty = !modelState.isLoading && modelState.error == null && modelState.items.isEmpty(),
-      sortConfig = modelState.sortConfig,
-      filters = modelState.filters,
+      sortConfig = sortConfig,
+      filters = filters,
       viewMode = viewMode,
       availableGenres = modelState.availableGenres,
       availableYears = modelState.availableYears,
@@ -48,22 +77,31 @@ class MoviesLibraryCompositor(
 
   override suspend fun onIntent(intent: MoviesLibraryIntent) {
     when(intent) {
-      MoviesLibraryIntent.LoadMore -> moviesModel.loadMore(key.libraryId)
-      MoviesLibraryIntent.Refresh -> moviesModel.refresh(key.libraryId)
-      MoviesLibraryIntent.RetryLoad -> moviesModel.loadInitial(key.libraryId)
+      MoviesLibraryIntent.LoadMore -> moviesModel.loadMore(
+        libraryId = key.libraryId,
+        sortConfig = currentSortConfig,
+        filters = currentFilters,
+      )
+
+      MoviesLibraryIntent.Refresh -> moviesModel.loadInitial(
+        libraryId = key.libraryId,
+        sortConfig = currentSortConfig,
+        filters = currentFilters,
+      )
+
+      MoviesLibraryIntent.RetryLoad -> moviesModel.loadInitial(
+        libraryId = key.libraryId,
+        sortConfig = currentSortConfig,
+        filters = currentFilters,
+      )
+
       is MoviesLibraryIntent.SelectMovie -> navigator.navigateToMovieDetail(intent.movieId)
 
-      is MoviesLibraryIntent.ChangeSortOption -> {
-        moviesModel.updateSortConfig(
-          LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder),
-        )
-        moviesModel.loadInitial(key.libraryId)
-      }
+      is MoviesLibraryIntent.ChangeSortOption ->
+        sortMutations.send(LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder))
 
-      is MoviesLibraryIntent.ChangeFilters -> {
-        moviesModel.updateFilters(intent.filters)
-        moviesModel.loadInitial(key.libraryId)
-      }
+      is MoviesLibraryIntent.ChangeFilters ->
+        filterMutations.send(intent.filters)
 
       is MoviesLibraryIntent.ChangeViewMode ->
         viewMode = intent.viewMode

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/model/MoviesLibraryModel.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/model/MoviesLibraryModel.kt
@@ -23,8 +23,6 @@ data class MoviesLibraryState(
   val isLoadingMore: Boolean = false,
   val hasMore: Boolean = false,
   val error: MoviesLibraryModelError? = null,
-  val sortConfig: LibrarySortConfig = LibrarySortConfig(),
-  val filters: LibraryFilters = LibraryFilters(),
   val availableGenres: List<String> = emptyList(),
   val availableYears: List<Int> = emptyList(),
 )
@@ -46,19 +44,23 @@ class MoviesLibraryModel(
   @Composable
   override fun currentState(): MoviesLibraryState = state
 
-  suspend fun loadInitial(libraryId: String) {
+  suspend fun loadInitial(
+    libraryId: String,
+    sortConfig: LibrarySortConfig,
+    filters: LibraryFilters,
+  ) {
     currentStartIndex = 0
     state = state.copy(isLoading = true, error = null, items = emptyList())
 
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("Movie"),
-      sortBy = state.sortConfig.sortBy,
-      sortOrder = state.sortConfig.sortOrder,
+      sortBy = sortConfig.sortBy,
+      sortOrder = sortConfig.sortOrder,
       startIndex = 0,
       limit = PAGE_SIZE,
-      genres = state.filters.genres.ifEmpty { null },
-      years = state.filters.years.ifEmpty { null },
+      genres = filters.genres.ifEmpty { null },
+      years = filters.years.ifEmpty { null },
     )
 
     state = if(result.isSuccess()) {
@@ -81,7 +83,11 @@ class MoviesLibraryModel(
     }
   }
 
-  suspend fun loadMore(libraryId: String) {
+  suspend fun loadMore(
+    libraryId: String,
+    sortConfig: LibrarySortConfig,
+    filters: LibraryFilters,
+  ) {
     if(state.isLoadingMore || !state.hasMore) return
 
     state = state.copy(isLoadingMore = true)
@@ -89,12 +95,12 @@ class MoviesLibraryModel(
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("Movie"),
-      sortBy = state.sortConfig.sortBy,
-      sortOrder = state.sortConfig.sortOrder,
+      sortBy = sortConfig.sortBy,
+      sortOrder = sortConfig.sortOrder,
       startIndex = currentStartIndex,
       limit = PAGE_SIZE,
-      genres = state.filters.genres.ifEmpty { null },
-      years = state.filters.years.ifEmpty { null },
+      genres = filters.genres.ifEmpty { null },
+      years = filters.years.ifEmpty { null },
     )
 
     state = if(result.isSuccess()) {
@@ -111,18 +117,6 @@ class MoviesLibraryModel(
     else {
       state.copy(isLoadingMore = false)
     }
-  }
-
-  suspend fun refresh(libraryId: String) {
-    loadInitial(libraryId)
-  }
-
-  fun updateSortConfig(sortConfig: LibrarySortConfig) {
-    state = state.copy(sortConfig = sortConfig)
-  }
-
-  fun updateFilters(filters: LibraryFilters) {
-    state = state.copy(filters = filters)
   }
 
   suspend fun loadAvailableFilters(libraryId: String) {

--- a/screens/library-movies/src/commonTest/kotlin/com/eygraber/jellyfin/screens/library/movies/model/MoviesLibraryModelTest.kt
+++ b/screens/library-movies/src/commonTest/kotlin/com/eygraber/jellyfin/screens/library/movies/model/MoviesLibraryModelTest.kt
@@ -55,7 +55,7 @@ class MoviesLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -80,7 +80,7 @@ class MoviesLibraryModelTest {
         isEphemeral = true,
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -100,7 +100,7 @@ class MoviesLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -123,7 +123,7 @@ class MoviesLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.hasMore.shouldBeTrue()
@@ -142,7 +142,7 @@ class MoviesLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       fakeRepository.getItemsResult = JellyfinResult.Success(
         PaginatedResult(
@@ -152,7 +152,7 @@ class MoviesLibraryModelTest {
         ),
       )
 
-      model.loadMore("lib-1")
+      model.loadMoreDefault()
 
       val state = model.stateForTest
       state.items.size shouldBe 2
@@ -173,9 +173,9 @@ class MoviesLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
-      model.loadMore("lib-1")
+      model.loadMoreDefault()
 
       val state = model.stateForTest
       state.items.size shouldBe 1
@@ -194,7 +194,7 @@ class MoviesLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.items[0].imageUrl.shouldBeNull()
@@ -202,34 +202,23 @@ class MoviesLibraryModelTest {
   }
 
   @Test
-  fun updateSortConfig_changes_sort_configuration() {
+  fun loadInitial_passes_sort_and_filters_to_repository() {
     runTest {
-      val newConfig = LibrarySortConfig(
+      val sortConfig = LibrarySortConfig(
         sortBy = ItemSortBy.CommunityRating,
         sortOrder = SortOrder.Descending,
       )
-
-      model.updateSortConfig(newConfig)
-
-      val state = model.stateForTest
-      state.sortConfig.sortBy shouldBe ItemSortBy.CommunityRating
-      state.sortConfig.sortOrder shouldBe SortOrder.Descending
-    }
-  }
-
-  @Test
-  fun updateFilters_changes_active_filters() {
-    runTest {
-      val newFilters = LibraryFilters(
+      val filters = LibraryFilters(
         genres = listOf("Action", "Comedy"),
         years = listOf(2020, 2021),
       )
 
-      model.updateFilters(newFilters)
+      model.loadInitial(libraryId = "lib-1", sortConfig = sortConfig, filters = filters)
 
-      val state = model.stateForTest
-      state.filters.genres shouldBe listOf("Action", "Comedy")
-      state.filters.years shouldBe listOf(2020, 2021)
+      fakeRepository.lastSortBy shouldBe ItemSortBy.CommunityRating
+      fakeRepository.lastSortOrder shouldBe SortOrder.Descending
+      fakeRepository.lastGenres shouldBe listOf("Action", "Comedy")
+      fakeRepository.lastYears shouldBe listOf(2020, 2021)
     }
   }
 
@@ -255,35 +244,12 @@ class MoviesLibraryModelTest {
     }
   }
 
-  @Test
-  fun refresh_reloads_items_from_beginning() {
-    runTest {
-      fakeRepository.getItemsResult = JellyfinResult.Success(
-        PaginatedResult(
-          items = listOf(createLibraryItem(id = "movie-1", name = "Movie 1")),
-          totalRecordCount = 1,
-          startIndex = 0,
-        ),
-      )
+  private suspend fun MoviesLibraryModel.loadInitialDefault() {
+    loadInitial(libraryId = "lib-1", sortConfig = LibrarySortConfig(), filters = LibraryFilters())
+  }
 
-      model.loadInitial("lib-1")
-
-      fakeRepository.getItemsResult = JellyfinResult.Success(
-        PaginatedResult(
-          items = listOf(
-            createLibraryItem(id = "movie-1", name = "Movie 1"),
-            createLibraryItem(id = "movie-2", name = "Movie 2"),
-          ),
-          totalRecordCount = 2,
-          startIndex = 0,
-        ),
-      )
-
-      model.refresh("lib-1")
-
-      val state = model.stateForTest
-      state.items.size shouldBe 2
-    }
+  private suspend fun MoviesLibraryModel.loadMoreDefault() {
+    loadMore(libraryId = "lib-1", sortConfig = LibrarySortConfig(), filters = LibraryFilters())
   }
 
   private fun createLibraryItem(
@@ -325,6 +291,11 @@ private class FakeItemsRepository : ItemsRepository {
 
   var getSimilarItemsResult: JellyfinResult<List<LibraryItem>> = JellyfinResult.Success(emptyList())
 
+  var lastSortBy: ItemSortBy? = null
+  var lastSortOrder: SortOrder? = null
+  var lastGenres: List<String>? = null
+  var lastYears: List<Int>? = null
+
   override suspend fun getItems(
     parentId: String,
     includeItemTypes: List<String>?,
@@ -336,7 +307,13 @@ private class FakeItemsRepository : ItemsRepository {
     years: List<Int>?,
     searchTerm: String?,
     fields: List<String>?,
-  ): JellyfinResult<PaginatedResult<LibraryItem>> = getItemsResult
+  ): JellyfinResult<PaginatedResult<LibraryItem>> {
+    lastSortBy = sortBy
+    lastSortOrder = sortOrder
+    lastGenres = genres
+    lastYears = years
+    return getItemsResult
+  }
 
   override suspend fun getItem(itemId: String): JellyfinResult<LibraryItem> = getItemResult
 

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
@@ -2,11 +2,15 @@ package com.eygraber.jellyfin.screens.library.music
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.screens.library.music.model.MusicLibraryModel
 import com.eygraber.jellyfin.screens.library.music.model.MusicLibraryModelError
 import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
+import com.eygraber.jellyfin.ui.library.controls.rememberLibrarySortConfig
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.channels.Channel
 
 @Inject
 class MusicLibraryCompositor(
@@ -14,13 +18,25 @@ class MusicLibraryCompositor(
   private val navigator: MusicLibraryNavigator,
   private val musicModel: MusicLibraryModel,
 ) : ViceCompositor<MusicLibraryIntent, MusicLibraryViewState> {
+  // Sort lives in `composite()` via rememberSaveable so it survives composition disposal when the
+  // user navigates into an item and back. `onIntent` writes through this channel and the drain
+  // coroutine updates the saved state inside the composition.
+  private val sortMutations = Channel<LibrarySortConfig>(Channel.CONFLATED)
+  @Volatile private var currentSortConfig: LibrarySortConfig = LibrarySortConfig()
 
   @Composable
   override fun composite(): MusicLibraryViewState {
-    val modelState = musicModel.currentState()
+    var sortConfig by rememberLibrarySortConfig()
 
     LaunchedEffect(Unit) {
-      musicModel.loadInitial(key.libraryId)
+      for(next in sortMutations) sortConfig = next
+    }
+
+    val modelState = musicModel.currentState()
+
+    LaunchedEffect(sortConfig) {
+      currentSortConfig = sortConfig
+      musicModel.loadInitial(key.libraryId, sortConfig)
     }
 
     return MusicLibraryViewState(
@@ -35,25 +51,21 @@ class MusicLibraryCompositor(
         modelState.error == null &&
         modelState.artists.isEmpty() &&
         modelState.albums.isEmpty(),
-      sortConfig = modelState.sortConfig,
+      sortConfig = sortConfig,
     )
   }
 
   override suspend fun onIntent(intent: MusicLibraryIntent) {
     when(intent) {
-      MusicLibraryIntent.LoadMore -> musicModel.loadMore(key.libraryId)
-      MusicLibraryIntent.Refresh -> musicModel.refresh(key.libraryId)
-      MusicLibraryIntent.RetryLoad -> musicModel.loadInitial(key.libraryId)
-      is MusicLibraryIntent.SelectTab -> musicModel.switchTab(key.libraryId, intent.tab)
+      MusicLibraryIntent.LoadMore -> musicModel.loadMore(key.libraryId, currentSortConfig)
+      MusicLibraryIntent.Refresh -> musicModel.loadInitial(key.libraryId, currentSortConfig)
+      MusicLibraryIntent.RetryLoad -> musicModel.loadInitial(key.libraryId, currentSortConfig)
+      is MusicLibraryIntent.SelectTab -> musicModel.switchTab(key.libraryId, intent.tab, currentSortConfig)
       is MusicLibraryIntent.SelectArtist -> navigator.navigateToArtistAlbums(intent.artistId)
       is MusicLibraryIntent.SelectAlbum -> navigator.navigateToAlbumTracks(intent.albumId)
 
-      is MusicLibraryIntent.ChangeSortOption -> {
-        musicModel.updateSortConfig(
-          LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder),
-        )
-        musicModel.loadInitial(key.libraryId)
-      }
+      is MusicLibraryIntent.ChangeSortOption ->
+        sortMutations.send(LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder))
 
       MusicLibraryIntent.NavigateBack -> navigator.navigateBack()
     }

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/model/MusicLibraryModel.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/model/MusicLibraryModel.kt
@@ -24,7 +24,6 @@ data class MusicLibraryState(
   val isLoadingMore: Boolean = false,
   val hasMore: Boolean = false,
   val error: MusicLibraryModelError? = null,
-  val sortConfig: LibrarySortConfig = LibrarySortConfig(),
 )
 
 enum class MusicLibraryModelError {
@@ -44,53 +43,45 @@ class MusicLibraryModel(
   @Composable
   override fun currentState(): MusicLibraryState = state
 
-  suspend fun loadInitial(libraryId: String) {
+  suspend fun loadInitial(libraryId: String, sortConfig: LibrarySortConfig) {
     currentStartIndex = 0
     state = state.copy(isLoading = true, error = null, artists = emptyList(), albums = emptyList())
 
     when(state.selectedTab) {
-      MusicTab.Artists -> loadArtists(libraryId, isInitial = true)
-      MusicTab.Albums -> loadAlbums(libraryId, isInitial = true)
+      MusicTab.Artists -> loadArtists(libraryId, sortConfig, isInitial = true)
+      MusicTab.Albums -> loadAlbums(libraryId, sortConfig, isInitial = true)
     }
   }
 
-  suspend fun loadMore(libraryId: String) {
+  suspend fun loadMore(libraryId: String, sortConfig: LibrarySortConfig) {
     if(state.isLoadingMore || !state.hasMore) return
 
     state = state.copy(isLoadingMore = true)
 
     when(state.selectedTab) {
-      MusicTab.Artists -> loadArtists(libraryId, isInitial = false)
-      MusicTab.Albums -> loadAlbums(libraryId, isInitial = false)
+      MusicTab.Artists -> loadArtists(libraryId, sortConfig, isInitial = false)
+      MusicTab.Albums -> loadAlbums(libraryId, sortConfig, isInitial = false)
     }
   }
 
-  suspend fun switchTab(libraryId: String, tab: MusicTab) {
+  suspend fun switchTab(libraryId: String, tab: MusicTab, sortConfig: LibrarySortConfig) {
     if(state.selectedTab == tab) return
 
     currentStartIndex = 0
     state = MusicLibraryState(selectedTab = tab, isLoading = true)
 
     when(tab) {
-      MusicTab.Artists -> loadArtists(libraryId, isInitial = true)
-      MusicTab.Albums -> loadAlbums(libraryId, isInitial = true)
+      MusicTab.Artists -> loadArtists(libraryId, sortConfig, isInitial = true)
+      MusicTab.Albums -> loadAlbums(libraryId, sortConfig, isInitial = true)
     }
   }
 
-  suspend fun refresh(libraryId: String) {
-    loadInitial(libraryId)
-  }
-
-  fun updateSortConfig(sortConfig: LibrarySortConfig) {
-    state = state.copy(sortConfig = sortConfig)
-  }
-
-  private suspend fun loadArtists(libraryId: String, isInitial: Boolean) {
+  private suspend fun loadArtists(libraryId: String, sortConfig: LibrarySortConfig, isInitial: Boolean) {
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("MusicArtist"),
-      sortBy = state.sortConfig.sortBy,
-      sortOrder = state.sortConfig.sortOrder,
+      sortBy = sortConfig.sortBy,
+      sortOrder = sortConfig.sortOrder,
       startIndex = if(isInitial) 0 else currentStartIndex,
       limit = PAGE_SIZE,
     )
@@ -118,12 +109,12 @@ class MusicLibraryModel(
     }
   }
 
-  private suspend fun loadAlbums(libraryId: String, isInitial: Boolean) {
+  private suspend fun loadAlbums(libraryId: String, sortConfig: LibrarySortConfig, isInitial: Boolean) {
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("MusicAlbum"),
-      sortBy = state.sortConfig.sortBy,
-      sortOrder = state.sortConfig.sortOrder,
+      sortBy = sortConfig.sortBy,
+      sortOrder = sortConfig.sortOrder,
       startIndex = if(isInitial) 0 else currentStartIndex,
       limit = PAGE_SIZE,
     )

--- a/screens/library-music/src/commonTest/kotlin/com/eygraber/jellyfin/screens/library/music/model/MusicLibraryModelTest.kt
+++ b/screens/library-music/src/commonTest/kotlin/com/eygraber/jellyfin/screens/library/music/model/MusicLibraryModelTest.kt
@@ -9,6 +9,7 @@ import com.eygraber.jellyfin.data.items.SortOrder
 import com.eygraber.jellyfin.screens.library.music.MusicTab
 import com.eygraber.jellyfin.sdk.core.model.ImageType
 import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -51,7 +52,7 @@ class MusicLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitial("lib-1", LibrarySortConfig())
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -74,7 +75,7 @@ class MusicLibraryModelTest {
           startIndex = 0,
         ),
       )
-      model.loadInitial("lib-1")
+      model.loadInitial("lib-1", LibrarySortConfig())
 
       fakeRepository.getItemsResult = JellyfinResult.Success(
         PaginatedResult(
@@ -92,7 +93,7 @@ class MusicLibraryModelTest {
         ),
       )
 
-      model.switchTab("lib-1", MusicTab.Albums)
+      model.switchTab("lib-1", MusicTab.Albums, LibrarySortConfig())
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -112,7 +113,7 @@ class MusicLibraryModelTest {
         isEphemeral = true,
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitial("lib-1", LibrarySortConfig())
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -138,7 +139,7 @@ class MusicLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitial("lib-1", LibrarySortConfig())
 
       val state = model.stateForTest
       state.artists[0].imageUrl.shouldBeNull()

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
@@ -7,10 +7,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.screens.library.tvshows.model.TvShowsLibraryModel
 import com.eygraber.jellyfin.screens.library.tvshows.model.TvShowsLibraryModelError
+import com.eygraber.jellyfin.ui.library.controls.LibraryFilters
 import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
 import com.eygraber.jellyfin.ui.library.controls.LibraryViewMode
+import com.eygraber.jellyfin.ui.library.controls.rememberLibraryFilters
+import com.eygraber.jellyfin.ui.library.controls.rememberLibrarySortConfig
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.channels.Channel
 
 @Inject
 class TvShowsLibraryCompositor(
@@ -21,13 +25,36 @@ class TvShowsLibraryCompositor(
   private var isFilterSheetVisible by mutableStateOf(false)
   private var viewMode by mutableStateOf(LibraryViewMode.Grid)
 
+  // Sort/filter live in `composite()` via rememberSaveable so they survive composition disposal
+  // when the user navigates into an item and back. `onIntent` writes through these channels and
+  // the drain coroutines update the saved state inside the composition.
+  private val sortMutations = Channel<LibrarySortConfig>(Channel.CONFLATED)
+  private val filterMutations = Channel<LibraryFilters>(Channel.CONFLATED)
+
+  @Volatile private var currentSortConfig: LibrarySortConfig = LibrarySortConfig()
+  @Volatile private var currentFilters: LibraryFilters = LibraryFilters()
+
   @Composable
   override fun composite(): TvShowsLibraryViewState {
+    var sortConfig by rememberLibrarySortConfig()
+    var filters by rememberLibraryFilters()
+
+    LaunchedEffect(Unit) {
+      for(next in sortMutations) sortConfig = next
+    }
+    LaunchedEffect(Unit) {
+      for(next in filterMutations) filters = next
+    }
+
     val modelState = tvShowsModel.currentState()
 
     LaunchedEffect(Unit) {
-      tvShowsModel.loadInitial(key.libraryId)
       tvShowsModel.loadAvailableFilters(key.libraryId)
+    }
+    LaunchedEffect(sortConfig, filters) {
+      currentSortConfig = sortConfig
+      currentFilters = filters
+      tvShowsModel.loadInitial(key.libraryId, sortConfig, filters)
     }
 
     return TvShowsLibraryViewState(
@@ -37,8 +64,8 @@ class TvShowsLibraryCompositor(
       error = modelState.error?.toViewError(),
       hasMore = modelState.hasMore,
       isEmpty = !modelState.isLoading && modelState.error == null && modelState.items.isEmpty(),
-      sortConfig = modelState.sortConfig,
-      filters = modelState.filters,
+      sortConfig = sortConfig,
+      filters = filters,
       viewMode = viewMode,
       availableGenres = modelState.availableGenres,
       availableYears = modelState.availableYears,
@@ -48,22 +75,31 @@ class TvShowsLibraryCompositor(
 
   override suspend fun onIntent(intent: TvShowsLibraryIntent) {
     when(intent) {
-      TvShowsLibraryIntent.LoadMore -> tvShowsModel.loadMore(key.libraryId)
-      TvShowsLibraryIntent.Refresh -> tvShowsModel.refresh(key.libraryId)
-      TvShowsLibraryIntent.RetryLoad -> tvShowsModel.loadInitial(key.libraryId)
+      TvShowsLibraryIntent.LoadMore -> tvShowsModel.loadMore(
+        libraryId = key.libraryId,
+        sortConfig = currentSortConfig,
+        filters = currentFilters,
+      )
+
+      TvShowsLibraryIntent.Refresh -> tvShowsModel.loadInitial(
+        libraryId = key.libraryId,
+        sortConfig = currentSortConfig,
+        filters = currentFilters,
+      )
+
+      TvShowsLibraryIntent.RetryLoad -> tvShowsModel.loadInitial(
+        libraryId = key.libraryId,
+        sortConfig = currentSortConfig,
+        filters = currentFilters,
+      )
+
       is TvShowsLibraryIntent.SelectShow -> navigator.navigateToShowSeasons(intent.showId)
 
-      is TvShowsLibraryIntent.ChangeSortOption -> {
-        tvShowsModel.updateSortConfig(
-          LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder),
-        )
-        tvShowsModel.loadInitial(key.libraryId)
-      }
+      is TvShowsLibraryIntent.ChangeSortOption ->
+        sortMutations.send(LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder))
 
-      is TvShowsLibraryIntent.ChangeFilters -> {
-        tvShowsModel.updateFilters(intent.filters)
-        tvShowsModel.loadInitial(key.libraryId)
-      }
+      is TvShowsLibraryIntent.ChangeFilters ->
+        filterMutations.send(intent.filters)
 
       is TvShowsLibraryIntent.ChangeViewMode ->
         viewMode = intent.viewMode

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/model/TvShowsLibraryModel.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/model/TvShowsLibraryModel.kt
@@ -23,8 +23,6 @@ data class TvShowsLibraryState(
   val isLoadingMore: Boolean = false,
   val hasMore: Boolean = false,
   val error: TvShowsLibraryModelError? = null,
-  val sortConfig: LibrarySortConfig = LibrarySortConfig(),
-  val filters: LibraryFilters = LibraryFilters(),
   val availableGenres: List<String> = emptyList(),
   val availableYears: List<Int> = emptyList(),
 )
@@ -46,19 +44,23 @@ class TvShowsLibraryModel(
   @Composable
   override fun currentState(): TvShowsLibraryState = state
 
-  suspend fun loadInitial(libraryId: String) {
+  suspend fun loadInitial(
+    libraryId: String,
+    sortConfig: LibrarySortConfig,
+    filters: LibraryFilters,
+  ) {
     currentStartIndex = 0
     state = state.copy(isLoading = true, error = null, items = emptyList())
 
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("Series"),
-      sortBy = state.sortConfig.sortBy,
-      sortOrder = state.sortConfig.sortOrder,
+      sortBy = sortConfig.sortBy,
+      sortOrder = sortConfig.sortOrder,
       startIndex = 0,
       limit = PAGE_SIZE,
-      genres = state.filters.genres.ifEmpty { null },
-      years = state.filters.years.ifEmpty { null },
+      genres = filters.genres.ifEmpty { null },
+      years = filters.years.ifEmpty { null },
     )
 
     state = if(result.isSuccess()) {
@@ -81,7 +83,11 @@ class TvShowsLibraryModel(
     }
   }
 
-  suspend fun loadMore(libraryId: String) {
+  suspend fun loadMore(
+    libraryId: String,
+    sortConfig: LibrarySortConfig,
+    filters: LibraryFilters,
+  ) {
     if(state.isLoadingMore || !state.hasMore) return
 
     state = state.copy(isLoadingMore = true)
@@ -89,12 +95,12 @@ class TvShowsLibraryModel(
     val result = itemsRepository.getItems(
       parentId = libraryId,
       includeItemTypes = listOf("Series"),
-      sortBy = state.sortConfig.sortBy,
-      sortOrder = state.sortConfig.sortOrder,
+      sortBy = sortConfig.sortBy,
+      sortOrder = sortConfig.sortOrder,
       startIndex = currentStartIndex,
       limit = PAGE_SIZE,
-      genres = state.filters.genres.ifEmpty { null },
-      years = state.filters.years.ifEmpty { null },
+      genres = filters.genres.ifEmpty { null },
+      years = filters.years.ifEmpty { null },
     )
 
     state = if(result.isSuccess()) {
@@ -111,18 +117,6 @@ class TvShowsLibraryModel(
     else {
       state.copy(isLoadingMore = false)
     }
-  }
-
-  suspend fun refresh(libraryId: String) {
-    loadInitial(libraryId)
-  }
-
-  fun updateSortConfig(sortConfig: LibrarySortConfig) {
-    state = state.copy(sortConfig = sortConfig)
-  }
-
-  fun updateFilters(filters: LibraryFilters) {
-    state = state.copy(filters = filters)
   }
 
   suspend fun loadAvailableFilters(libraryId: String) {

--- a/screens/library-tvshows/src/commonTest/kotlin/com/eygraber/jellyfin/screens/library/tvshows/model/TvShowsLibraryModelTest.kt
+++ b/screens/library-tvshows/src/commonTest/kotlin/com/eygraber/jellyfin/screens/library/tvshows/model/TvShowsLibraryModelTest.kt
@@ -8,6 +8,8 @@ import com.eygraber.jellyfin.data.items.PaginatedResult
 import com.eygraber.jellyfin.data.items.SortOrder
 import com.eygraber.jellyfin.sdk.core.model.ImageType
 import com.eygraber.jellyfin.services.sdk.JellyfinLibraryService
+import com.eygraber.jellyfin.ui.library.controls.LibraryFilters
+import com.eygraber.jellyfin.ui.library.controls.LibrarySortConfig
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -52,7 +54,7 @@ class TvShowsLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -78,7 +80,7 @@ class TvShowsLibraryModelTest {
         isEphemeral = true,
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -98,7 +100,7 @@ class TvShowsLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.isLoading.shouldBeFalse()
@@ -119,7 +121,7 @@ class TvShowsLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       fakeRepository.getItemsResult = JellyfinResult.Success(
         PaginatedResult(
@@ -129,7 +131,7 @@ class TvShowsLibraryModelTest {
         ),
       )
 
-      model.loadMore("lib-1")
+      model.loadMoreDefault()
 
       val state = model.stateForTest
       state.items.size shouldBe 2
@@ -150,9 +152,9 @@ class TvShowsLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
-      model.loadMore("lib-1")
+      model.loadMoreDefault()
 
       val state = model.stateForTest
       state.items.size shouldBe 1
@@ -171,42 +173,27 @@ class TvShowsLibraryModelTest {
         ),
       )
 
-      model.loadInitial("lib-1")
+      model.loadInitialDefault()
 
       val state = model.stateForTest
       state.items[0].imageUrl.shouldBeNull()
     }
   }
 
-  @Test
-  fun refresh_reloads_items_from_beginning() {
-    runTest {
-      fakeRepository.getItemsResult = JellyfinResult.Success(
-        PaginatedResult(
-          items = listOf(createLibraryItem(id = "show-1", name = "Show 1")),
-          totalRecordCount = 1,
-          startIndex = 0,
-        ),
-      )
+  private suspend fun TvShowsLibraryModel.loadInitialDefault() {
+    loadInitial(
+      libraryId = "lib-1",
+      sortConfig = LibrarySortConfig(),
+      filters = LibraryFilters(),
+    )
+  }
 
-      model.loadInitial("lib-1")
-
-      fakeRepository.getItemsResult = JellyfinResult.Success(
-        PaginatedResult(
-          items = listOf(
-            createLibraryItem(id = "show-1", name = "Show 1"),
-            createLibraryItem(id = "show-2", name = "Show 2"),
-          ),
-          totalRecordCount = 2,
-          startIndex = 0,
-        ),
-      )
-
-      model.refresh("lib-1")
-
-      val state = model.stateForTest
-      state.items.size shouldBe 2
-    }
+  private suspend fun TvShowsLibraryModel.loadMoreDefault() {
+    loadMore(
+      libraryId = "lib-1",
+      sortConfig = LibrarySortConfig(),
+      filters = LibraryFilters(),
+    )
   }
 
   private fun createLibraryItem(

--- a/ui/library-controls/build.gradle.kts
+++ b/ui/library-controls/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
       implementation(libs.compose.material3)
       api(libs.compose.runtime)
       implementation(libs.compose.runtimeAnnotation)
+      implementation(libs.compose.runtimeSaveable)
       implementation(libs.compose.ui)
     }
   }

--- a/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/LibraryControlsSavers.kt
+++ b/ui/library-controls/src/commonMain/kotlin/com/eygraber/jellyfin/ui/library/controls/LibraryControlsSavers.kt
@@ -1,0 +1,53 @@
+package com.eygraber.jellyfin.ui.library.controls
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import com.eygraber.jellyfin.data.items.ItemSortBy
+import com.eygraber.jellyfin.data.items.SortOrder
+
+/**
+ * `rememberSaveable` saver for [LibrarySortConfig]. Persists across composition disposal — needed
+ * because Nav3's single-pane scene strategy disposes a screen's composition on forward navigation,
+ * which would otherwise reset sort selection when the user comes back.
+ */
+val LibrarySortConfigSaver: Saver<LibrarySortConfig, Any> = listSaver(
+  save = { sort -> listOf(sort.sortBy.name, sort.sortOrder.name) },
+  restore = { saved ->
+    LibrarySortConfig(
+      sortBy = ItemSortBy.valueOf(saved[0]),
+      sortOrder = SortOrder.valueOf(saved[1]),
+    )
+  },
+)
+
+/**
+ * `rememberSaveable` saver for [LibraryFilters]. Two parallel lists keep the saved form trivially
+ * round-trippable through Compose's default saved-state registry on every supported platform.
+ */
+val LibraryFiltersSaver: Saver<LibraryFilters, Any> = listSaver(
+  save = { filters -> listOf(filters.genres, filters.years.map(Int::toString)) },
+  restore = { saved ->
+    LibraryFilters(
+      genres = saved[0],
+      years = saved[1].map(String::toInt),
+    )
+  },
+)
+
+@Composable
+fun rememberLibrarySortConfig(
+  initial: LibrarySortConfig = LibrarySortConfig(),
+): MutableState<LibrarySortConfig> = rememberSaveable(stateSaver = LibrarySortConfigSaver) {
+  mutableStateOf(initial)
+}
+
+@Composable
+fun rememberLibraryFilters(
+  initial: LibraryFilters = LibraryFilters(),
+): MutableState<LibraryFilters> = rememberSaveable(stateSaver = LibraryFiltersSaver) {
+  mutableStateOf(initial)
+}


### PR DESCRIPTION
Closes #275

## Summary

- Sort (and on movies/tvshows, filter) selection is now preserved when the user taps into an item and navigates back. Verified across Movies, TV Shows, and Music library screens.
- Root cause: Nav3's single-pane scene strategy disposes a non-top-most entry's composition, which destroys the `ScreenScope` behind the DI-scoped Model. On back navigation the Model was reconstructed with defaults, so sort/filter silently reset.
- Fix: hoist sort/filter into `composite()` via `rememberSaveable`. The state now lives in the entry's `SaveableStateRegistry`, not the DI scope, so it survives composition disposal and (on platforms that back the registry with system saved state) process death.

## Architecture notes

- New savers in `:ui:library-controls` (`LibrarySortConfigSaver`, `LibraryFiltersSaver`) plus `rememberLibrarySortConfig` / `rememberLibraryFilters` helpers.
- Models no longer carry `sortConfig` / `filters` on their state — `loadInitial` / `loadMore` (and `switchTab` on music) receive them as parameters. `updateSortConfig` / `updateFilters` / `refresh` no longer exist on the models.
- Sort/filter intents are routed back into the saveable state via conflated `Channel`s drained inside `composite()` — mirrors the pattern used by `SearchFieldsModel` and called out in the Compose state-management rules. A volatile mirror of the latest values lets non-Compose intent handlers (Refresh / RetryLoad / LoadMore) read current sort+filter without putting them back on the model.

## Test plan

- [x] `:screens:library-movies:jvmTest`, `:screens:library-tvshows:jvmTest`, `:screens:library-music:jvmTest` all pass.
- [x] `./check --lite` passes.
- [ ] Manual on Desktop: open Movies, change sort to Date Added, click into a movie, back-navigate — sort stays Date Added and the list reflects it. Repeat for TV Shows (with filters) and Music (Artists / Albums tabs).
- [ ] Manual on Android: same flows, plus rotate the device after changing sort and back-navigate to confirm the value persists across the configuration change.