### PR TITLE
#286 Drop 700dp web padding so adaptive nav respects window size

### DIFF
--- a/apps/web/src/wasmJsMain/kotlin/com/eygraber/jellyfin/app/JellyfinWebApp.kt
+++ b/apps/web/src/wasmJsMain/kotlin/com/eygraber/jellyfin/app/JellyfinWebApp.kt
@@ -1,13 +1,10 @@
 package com.eygraber.jellyfin.app
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeViewport
 import com.eygraber.jellyfin.app.di.JellyfinWebAppGraph
 import com.eygraber.jellyfin.apps.shared.JellyfinAppSession
@@ -44,7 +41,6 @@ fun main() {
     JellyfinAppSession(
       onDarkMode = {},
       navGraph = navGraph,
-      modifier = Modifier.padding(horizontal = 700.dp),
     )
   }
 }

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryCompositor.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryCompositor.kt
@@ -15,6 +15,7 @@ import com.eygraber.jellyfin.ui.library.controls.rememberLibrarySortConfig
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.channels.Channel
+import kotlin.concurrent.Volatile
 
 @Inject
 class MoviesLibraryCompositor(

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
@@ -11,6 +11,7 @@ import com.eygraber.jellyfin.ui.library.controls.rememberLibrarySortConfig
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.channels.Channel
+import kotlin.concurrent.Volatile
 
 @Inject
 class MusicLibraryCompositor(

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
@@ -15,6 +15,7 @@ import com.eygraber.jellyfin.ui.library.controls.rememberLibrarySortConfig
 import com.eygraber.vice.ViceCompositor
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.channels.Channel
+import kotlin.concurrent.Volatile
 
 @Inject
 class TvShowsLibraryCompositor(


### PR DESCRIPTION
Closes #286

## Summary

- The web entry point was wrapping `JellyfinAppSession` in `Modifier.padding(horizontal = 700.dp)` — leftover template scaffolding (committed by the initial template generation, never removed). At anything but absurdly wide windows it collapsed the visible content region down to near zero, which is why the adaptive nav looked like it was stuck in mobile layout regardless of browser width. Desktop and iOS pass no modifier, which is why the bug was web-only.
- Removing the padding lets wasmJs render the same expanded / medium / compact navigation surfaces as Desktop and Android at the equivalent breakpoints.
- Bundled in a small hotfix: PR #310 left `kotlin.jvm.Volatile` imports on three Compositors. That compiles on JVM but breaks `compileKotlinWasmJs` (master is currently red for the web app). Switched to the multiplatform `kotlin.concurrent.Volatile` so common code builds for wasmJs.

## Test plan

- [x] `:apps:web:compileKotlinWasmJs` succeeds (was failing on master because of the `Volatile` import).
- [x] `./check --lite` passes.
- [ ] Manual: `./gradlew :apps:web:wasmJsBrowserDevelopmentRun`, open at full desktop window width, confirm the navigation drawer/rail renders and that resizing between compact/medium/expanded breakpoints reactively updates the layout.