### PR TITLE
#287 Fix WasmJs IrLinkageError on VideoPlayerService.VideoSurface

### DIFF
--- a/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/VideoPlayerService.kt
+++ b/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/VideoPlayerService.kt
@@ -55,9 +55,14 @@ interface VideoPlayerService {
    * On Android this binds to ExoPlayer's `PlayerSurface`. Platforms without a native
    * implementation render a placeholder (the player will already be reporting an error state
    * via [playbackState]).
+   *
+   * Note: `modifier` intentionally has no default. Composable members on an interface that carry a
+   * default argument trigger an `IrLinkageError` in the Kotlin/Wasm IR linker — the Compose
+   * compiler emits a `$default` synthetic that the wasmJs linker reads as missing on the
+   * implementing class. The single call site already passes a modifier explicitly.
    */
   @Composable
-  fun VideoSurface(modifier: Modifier = Modifier)
+  fun VideoSurface(modifier: Modifier)
 }
 
 /**


### PR DESCRIPTION
Closes #287

## Summary

- Removes the default `modifier: Modifier = Modifier` argument on `VideoPlayerService.VideoSurface`, which was the source of the `IrLinkageError: Abstract function 'VideoSurface' is not implemented in non-abstract class 'WasmJsVideoPlayerService'` whenever a video tried to start on web.
- Composable members declared on an interface with a default argument trip the Kotlin/Wasm IR linker — the Compose compiler emits a synthetic `\$default` companion that the wasmJs linker can't resolve against the platform overrides (overrides cannot re-declare the default). The non-wasm targets happen to tolerate this; wasmJs does not.
- The single call site (`PlayerContent` in `screens/video-player`) already passes a modifier explicitly, and all four platform overrides (Android / iOS / JVM / WasmJs) take a non-default `modifier`, so the change is no-op for callers.

## Note on the audio symptom

The issue also reports voice/center-channel audio missing on wasmJs playback. The HTML5 `<video>` element handles audio independently of the Compose surface, so that symptom is most likely orthogonal to the linkage error — probably a transcoding-profile issue on the server or in the web client's stream-URL parameters. If it persists after this fix lands, it'll need its own investigation against a running browser; recommend a separate issue at that point.

## Test plan

- [x] `:services:player:public:compileKotlinWasmJs`, `:services:player:impl:compileKotlinWasmJs`, `:apps:web:compileKotlinWasmJs` succeed.
- [x] `./check --lite` passes.
- [ ] Manual: `./gradlew :apps:web:wasmJsBrowserDevelopmentRun`, sign in, start any video — confirm no `IrLinkageError` in the browser console and the player surface composes. Capture audio-channel observation; file a follow-up if voice is still missing.