### PR TITLE
#308 Constrain Android PlayerSurface to source aspect ratio

### DIFF
--- a/services/player/impl/src/androidMain/kotlin/com/eygraber/jellyfin/services/player/impl/AndroidVideoPlayerService.kt
+++ b/services/player/impl/src/androidMain/kotlin/com/eygraber/jellyfin/services/player/impl/AndroidVideoPlayerService.kt
@@ -4,13 +4,19 @@ import android.content.Context
 import androidx.annotation.OptIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.compose.PlayerSurface
@@ -46,6 +52,11 @@ class AndroidVideoPlayerService(
   override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
   private var player: ExoPlayer? = null
+
+  // Compose-observable so VideoSurface recomposes with the right aspectRatio modifier as soon as
+  // ExoPlayer reports the video's intrinsic size. Without this, PlayerSurface stretches to fill
+  // whatever bounds it's given (visibly wrong in landscape).
+  private var videoSize: VideoSize by mutableStateOf(VideoSize.UNKNOWN)
 
   private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
   private var positionPollJob: Job? = null
@@ -89,6 +100,7 @@ class AndroidVideoPlayerService(
     positionPollJob = null
     player?.release()
     player = null
+    videoSize = VideoSize.UNKNOWN
     _playbackState.value = PlaybackState.Idle
   }
 
@@ -116,14 +128,31 @@ class AndroidVideoPlayerService(
   @Composable
   override fun VideoSurface(modifier: Modifier) {
     val currentPlayer = player
-    if(currentPlayer != null) {
+    if(currentPlayer == null) {
+      Box(modifier = modifier.fillMaxSize().background(Color.Black))
+      return
+    }
+
+    // Use the source's display aspect (intrinsic width × pixel-aspect-ratio ÷ height) so anamorphic
+    // sources (e.g. 720x480 stored anamorphically as 16:9) render correctly. Until ExoPlayer reports
+    // the video size, fall back to fillMaxSize — the placeholder surface won't be visible long.
+    val aspect = videoSize
+      .takeIf { it.width > 0 && it.height > 0 }
+      ?.let { it.width * it.pixelWidthHeightRatio / it.height }
+
+    Box(
+      modifier = modifier.fillMaxSize().background(Color.Black),
+      contentAlignment = Alignment.Center,
+    ) {
       PlayerSurface(
         player = currentPlayer,
-        modifier = modifier,
+        modifier = if(aspect != null) {
+          Modifier.fillMaxSize().aspectRatio(aspect)
+        }
+        else {
+          Modifier.fillMaxSize()
+        },
       )
-    }
-    else {
-      Box(modifier = modifier.fillMaxSize().background(Color.Black))
     }
   }
 
@@ -144,6 +173,10 @@ class AndroidVideoPlayerService(
       else {
         stopPositionPolling()
       }
+    }
+
+    override fun onVideoSizeChanged(newVideoSize: VideoSize) {
+      videoSize = newVideoSize
     }
 
     override fun onPlayerError(error: PlaybackException) {


### PR DESCRIPTION
Closes #308

## Summary

- Android playback was stretching the video in landscape because `androidx.media3.ui.compose.PlayerSurface` doesn't apply the intrinsic aspect ratio — it renders frames into whatever bounds the modifier dictates. The screen passed `Modifier.fillMaxSize()`, so in landscape the surface filled the full window and ExoPlayer scaled the picture to match. Portrait roughly matched typical movie aspect, which masked the bug.
- Fix: subscribe to `Player.Listener.onVideoSizeChanged`, store the `VideoSize` as a Compose-observable property, and wrap `PlayerSurface` in a centered `Box` with `Modifier.aspectRatio(width × pixelWidthHeightRatio / height)`. The PAR multiplication keeps anamorphic sources (e.g. DVDs encoded as 720×480 with 16:9 PAR) displaying correctly.
- `release()` resets `videoSize` so it doesn't leak across stream changes.

Other platforms already letterbox correctly:
- iOS uses `AVPlayerViewController` (defaults to `AVLayerVideoGravityResizeAspect`).
- JVM uses `Image(contentScale = ContentScale.Fit)`.
- Web uses an overlaid HTML5 `<video>` element which auto-fits.

## Test plan

- [x] `:apps:android:assembleDevDebug` succeeds.
- [x] `./check --lite` passes.
- [ ] Manual Android phone: start playback of a 16:9 title in portrait → confirm correct aspect with letterboxing top/bottom; rotate to landscape → confirm aspect remains correct (no stretch / squish), with pillarboxing if the video is narrower than the window. Repeat with a ~2.39:1 cinema title to verify.
- [ ] Spot-check iOS, Desktop, Web — should be unaffected.