### PR TITLE
#311 Scroll back to last-selected item on category back-nav

### DIFF
--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryCompositor.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryCompositor.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.screens.library.movies.model.MoviesLibraryModel
 import com.eygraber.jellyfin.screens.library.movies.model.MoviesLibraryModelError
@@ -32,6 +33,11 @@ class MoviesLibraryCompositor(
   private val sortMutations = Channel<LibrarySortConfig>(Channel.CONFLATED)
   private val filterMutations = Channel<LibraryFilters>(Channel.CONFLATED)
 
+  // Rendezvous so `SelectMovie` waits for the saveable id to be committed before navigating —
+  // otherwise the composition can be torn down before the drain assigns, and the back-nav restore
+  // would have no last-selected id to scroll to.
+  private val selectionMutations = Channel<String?>()
+
   // Plain mirrors of the latest sort/filter, kept in sync from within `composite()` so non-Compose
   // callers (Refresh / RetryLoad / LoadMore intents) can read the current values without observers.
   @Volatile private var currentSortConfig: LibrarySortConfig = LibrarySortConfig()
@@ -41,12 +47,16 @@ class MoviesLibraryCompositor(
   override fun composite(): MoviesLibraryViewState {
     var sortConfig by rememberLibrarySortConfig()
     var filters by rememberLibraryFilters()
+    var lastSelectedItemId by rememberSaveable { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
       for(next in sortMutations) sortConfig = next
     }
     LaunchedEffect(Unit) {
       for(next in filterMutations) filters = next
+    }
+    LaunchedEffect(Unit) {
+      for(next in selectionMutations) lastSelectedItemId = next
     }
 
     val modelState = moviesModel.currentState()
@@ -73,6 +83,7 @@ class MoviesLibraryCompositor(
       availableGenres = modelState.availableGenres,
       availableYears = modelState.availableYears,
       isFilterSheetVisible = isFilterSheetVisible,
+      selectedItemId = lastSelectedItemId,
     )
   }
 
@@ -96,7 +107,13 @@ class MoviesLibraryCompositor(
         filters = currentFilters,
       )
 
-      is MoviesLibraryIntent.SelectMovie -> navigator.navigateToMovieDetail(intent.movieId)
+      is MoviesLibraryIntent.SelectMovie -> {
+        // Send-then-navigate: with a rendezvous channel, send() suspends until the drain commits
+        // the id to rememberSaveable. Once that's done, navigation can disposable composition
+        // without losing the last-selected id needed to scroll-restore on back-nav.
+        selectionMutations.send(intent.movieId)
+        navigator.navigateToMovieDetail(intent.movieId)
+      }
 
       is MoviesLibraryIntent.ChangeSortOption ->
         sortMutations.send(LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder))

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryView.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryView.kt
@@ -118,6 +118,7 @@ internal fun MoviesLibraryView(
               items = state.items,
               isLoadingMore = state.isLoadingMore,
               hasMore = state.hasMore,
+              selectedItemId = state.selectedItemId,
               onMovieClick = { movieId -> onIntent(MoviesLibraryIntent.SelectMovie(movieId)) },
               onLoadMore = { onIntent(MoviesLibraryIntent.LoadMore) },
             )

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryViewState.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/MoviesLibraryViewState.kt
@@ -19,6 +19,7 @@ data class MoviesLibraryViewState(
   val availableGenres: List<String> = emptyList(),
   val availableYears: List<Int> = emptyList(),
   val isFilterSheetVisible: Boolean = false,
+  val selectedItemId: String? = null,
 ) {
   companion object {
     val Loading = MoviesLibraryViewState(isLoading = true)

--- a/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/components/MoviePosterGrid.kt
+++ b/screens/library-movies/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/movies/components/MoviePosterGrid.kt
@@ -43,6 +43,7 @@ internal fun MoviePosterGrid(
   items: List<MovieItem>,
   isLoadingMore: Boolean,
   hasMore: Boolean,
+  selectedItemId: String?,
   onMovieClick: (movieId: String) -> Unit,
   onLoadMore: () -> Unit,
   modifier: Modifier = Modifier,
@@ -62,6 +63,20 @@ internal fun MoviePosterGrid(
   LaunchedEffect(shouldLoadMore) {
     if(shouldLoadMore) {
       currentOnLoadMore()
+    }
+  }
+
+  // Best-effort scroll-restore: when the screen is recomposed with a remembered last-selected id,
+  // jump to that item once it lands in the loaded set. Skip if the user has already scrolled away
+  // (avoids snapping back when loadMore appends pages).
+  LaunchedEffect(items, selectedItemId) {
+    if(selectedItemId != null &&
+      items.isNotEmpty() &&
+      gridState.firstVisibleItemIndex == 0 &&
+      gridState.firstVisibleItemScrollOffset == 0
+    ) {
+      val index = items.indexOfFirst { it.id == selectedItemId }
+      if(index >= 0) gridState.scrollToItem(index)
     }
   }
 

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryCompositor.kt
@@ -3,6 +3,8 @@ package com.eygraber.jellyfin.screens.library.music
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.screens.library.music.model.MusicLibraryModel
 import com.eygraber.jellyfin.screens.library.music.model.MusicLibraryModelError
@@ -25,12 +27,20 @@ class MusicLibraryCompositor(
   private val sortMutations = Channel<LibrarySortConfig>(Channel.CONFLATED)
   @Volatile private var currentSortConfig: LibrarySortConfig = LibrarySortConfig()
 
+  // Rendezvous so SelectArtist/SelectAlbum waits for the saveable id to be committed before
+  // navigating. See MoviesLibraryCompositor for full rationale.
+  private val selectionMutations = Channel<String?>()
+
   @Composable
   override fun composite(): MusicLibraryViewState {
     var sortConfig by rememberLibrarySortConfig()
+    var lastSelectedItemId by rememberSaveable { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
       for(next in sortMutations) sortConfig = next
+    }
+    LaunchedEffect(Unit) {
+      for(next in selectionMutations) lastSelectedItemId = next
     }
 
     val modelState = musicModel.currentState()
@@ -53,6 +63,7 @@ class MusicLibraryCompositor(
         modelState.artists.isEmpty() &&
         modelState.albums.isEmpty(),
       sortConfig = sortConfig,
+      selectedItemId = lastSelectedItemId,
     )
   }
 
@@ -62,8 +73,15 @@ class MusicLibraryCompositor(
       MusicLibraryIntent.Refresh -> musicModel.loadInitial(key.libraryId, currentSortConfig)
       MusicLibraryIntent.RetryLoad -> musicModel.loadInitial(key.libraryId, currentSortConfig)
       is MusicLibraryIntent.SelectTab -> musicModel.switchTab(key.libraryId, intent.tab, currentSortConfig)
-      is MusicLibraryIntent.SelectArtist -> navigator.navigateToArtistAlbums(intent.artistId)
-      is MusicLibraryIntent.SelectAlbum -> navigator.navigateToAlbumTracks(intent.albumId)
+      is MusicLibraryIntent.SelectArtist -> {
+        // Send-then-navigate so the saveable id is committed before composition disposes.
+        selectionMutations.send(intent.artistId)
+        navigator.navigateToArtistAlbums(intent.artistId)
+      }
+      is MusicLibraryIntent.SelectAlbum -> {
+        selectionMutations.send(intent.albumId)
+        navigator.navigateToAlbumTracks(intent.albumId)
+      }
 
       is MusicLibraryIntent.ChangeSortOption ->
         sortMutations.send(LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder))

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryView.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryView.kt
@@ -97,6 +97,7 @@ internal fun MusicLibraryView(
               artists = state.artists,
               isLoadingMore = state.isLoadingMore,
               hasMore = state.hasMore,
+              selectedItemId = state.selectedItemId,
               onArtistClick = { artistId ->
                 onIntent(MusicLibraryIntent.SelectArtist(artistId))
               },
@@ -106,6 +107,7 @@ internal fun MusicLibraryView(
               albums = state.albums,
               isLoadingMore = state.isLoadingMore,
               hasMore = state.hasMore,
+              selectedItemId = state.selectedItemId,
               onAlbumClick = { albumId ->
                 onIntent(MusicLibraryIntent.SelectAlbum(albumId))
               },

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryViewState.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/MusicLibraryViewState.kt
@@ -14,6 +14,7 @@ data class MusicLibraryViewState(
   val hasMore: Boolean = false,
   val isEmpty: Boolean = false,
   val sortConfig: LibrarySortConfig = LibrarySortConfig(),
+  val selectedItemId: String? = null,
 ) {
   companion object {
     val Loading = MusicLibraryViewState(isLoading = true)

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/components/AlbumsGrid.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/components/AlbumsGrid.kt
@@ -38,6 +38,7 @@ internal fun AlbumsGrid(
   albums: List<AlbumItem>,
   isLoadingMore: Boolean,
   hasMore: Boolean,
+  selectedItemId: String?,
   onAlbumClick: (albumId: String) -> Unit,
   onLoadMore: () -> Unit,
   modifier: Modifier = Modifier,
@@ -57,6 +58,17 @@ internal fun AlbumsGrid(
   LaunchedEffect(shouldLoadMore) {
     if(shouldLoadMore) {
       currentOnLoadMore()
+    }
+  }
+
+  LaunchedEffect(albums, selectedItemId) {
+    if(selectedItemId != null &&
+      albums.isNotEmpty() &&
+      gridState.firstVisibleItemIndex == 0 &&
+      gridState.firstVisibleItemScrollOffset == 0
+    ) {
+      val index = albums.indexOfFirst { it.id == selectedItemId }
+      if(index >= 0) gridState.scrollToItem(index)
     }
   }
 

--- a/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/components/ArtistsList.kt
+++ b/screens/library-music/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/music/components/ArtistsList.kt
@@ -39,6 +39,7 @@ internal fun ArtistsList(
   artists: List<ArtistItem>,
   isLoadingMore: Boolean,
   hasMore: Boolean,
+  selectedItemId: String?,
   onArtistClick: (artistId: String) -> Unit,
   onLoadMore: () -> Unit,
   modifier: Modifier = Modifier,
@@ -58,6 +59,17 @@ internal fun ArtistsList(
   LaunchedEffect(shouldLoadMore) {
     if(shouldLoadMore) {
       currentOnLoadMore()
+    }
+  }
+
+  LaunchedEffect(artists, selectedItemId) {
+    if(selectedItemId != null &&
+      artists.isNotEmpty() &&
+      listState.firstVisibleItemIndex == 0 &&
+      listState.firstVisibleItemScrollOffset == 0
+    ) {
+      val index = artists.indexOfFirst { it.id == selectedItemId }
+      if(index >= 0) listState.scrollToItem(index)
     }
   }
 

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryCompositor.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.eygraber.jellyfin.screens.library.tvshows.model.TvShowsLibraryModel
 import com.eygraber.jellyfin.screens.library.tvshows.model.TvShowsLibraryModelError
@@ -32,6 +33,11 @@ class TvShowsLibraryCompositor(
   private val sortMutations = Channel<LibrarySortConfig>(Channel.CONFLATED)
   private val filterMutations = Channel<LibraryFilters>(Channel.CONFLATED)
 
+  // Rendezvous so SelectShow waits for the saveable id to be committed before navigating —
+  // otherwise the composition can be torn down before the drain assigns, and the back-nav restore
+  // would have no last-selected id to scroll to.
+  private val selectionMutations = Channel<String?>()
+
   @Volatile private var currentSortConfig: LibrarySortConfig = LibrarySortConfig()
   @Volatile private var currentFilters: LibraryFilters = LibraryFilters()
 
@@ -39,12 +45,16 @@ class TvShowsLibraryCompositor(
   override fun composite(): TvShowsLibraryViewState {
     var sortConfig by rememberLibrarySortConfig()
     var filters by rememberLibraryFilters()
+    var lastSelectedItemId by rememberSaveable { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
       for(next in sortMutations) sortConfig = next
     }
     LaunchedEffect(Unit) {
       for(next in filterMutations) filters = next
+    }
+    LaunchedEffect(Unit) {
+      for(next in selectionMutations) lastSelectedItemId = next
     }
 
     val modelState = tvShowsModel.currentState()
@@ -71,6 +81,7 @@ class TvShowsLibraryCompositor(
       availableGenres = modelState.availableGenres,
       availableYears = modelState.availableYears,
       isFilterSheetVisible = isFilterSheetVisible,
+      selectedItemId = lastSelectedItemId,
     )
   }
 
@@ -94,7 +105,12 @@ class TvShowsLibraryCompositor(
         filters = currentFilters,
       )
 
-      is TvShowsLibraryIntent.SelectShow -> navigator.navigateToShowSeasons(intent.showId)
+      is TvShowsLibraryIntent.SelectShow -> {
+        // Send-then-navigate so the saveable id is committed before composition disposes. See
+        // MoviesLibraryCompositor for full rationale.
+        selectionMutations.send(intent.showId)
+        navigator.navigateToShowSeasons(intent.showId)
+      }
 
       is TvShowsLibraryIntent.ChangeSortOption ->
         sortMutations.send(LibrarySortConfig(sortBy = intent.sortBy, sortOrder = intent.sortOrder))

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryView.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryView.kt
@@ -118,6 +118,7 @@ internal fun TvShowsLibraryView(
               items = state.items,
               isLoadingMore = state.isLoadingMore,
               hasMore = state.hasMore,
+              selectedItemId = state.selectedItemId,
               onShowClick = { showId -> onIntent(TvShowsLibraryIntent.SelectShow(showId)) },
               onLoadMore = { onIntent(TvShowsLibraryIntent.LoadMore) },
             )

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryViewState.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/TvShowsLibraryViewState.kt
@@ -19,6 +19,7 @@ data class TvShowsLibraryViewState(
   val availableGenres: List<String> = emptyList(),
   val availableYears: List<Int> = emptyList(),
   val isFilterSheetVisible: Boolean = false,
+  val selectedItemId: String? = null,
 ) {
   companion object {
     val Loading = TvShowsLibraryViewState(isLoading = true)

--- a/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/components/TvShowPosterGrid.kt
+++ b/screens/library-tvshows/src/commonMain/kotlin/com/eygraber/jellyfin/screens/library/tvshows/components/TvShowPosterGrid.kt
@@ -40,6 +40,7 @@ internal fun TvShowPosterGrid(
   items: List<TvShowItem>,
   isLoadingMore: Boolean,
   hasMore: Boolean,
+  selectedItemId: String?,
   onShowClick: (showId: String) -> Unit,
   onLoadMore: () -> Unit,
   modifier: Modifier = Modifier,
@@ -59,6 +60,17 @@ internal fun TvShowPosterGrid(
   LaunchedEffect(shouldLoadMore) {
     if(shouldLoadMore) {
       currentOnLoadMore()
+    }
+  }
+
+  LaunchedEffect(items, selectedItemId) {
+    if(selectedItemId != null &&
+      items.isNotEmpty() &&
+      gridState.firstVisibleItemIndex == 0 &&
+      gridState.firstVisibleItemScrollOffset == 0
+    ) {
+      val index = items.indexOfFirst { it.id == selectedItemId }
+      if(index >= 0) gridState.scrollToItem(index)
     }
   }
 


### PR DESCRIPTION
Closes #311

## Summary

- Building on PR #310's pattern: persist `lastSelectedItemId` in the Compositor via `rememberSaveable`, drained from a rendezvous `Channel<String?>` so the saveable id commits to the entry's `SaveableStateRegistry` *before* navigation tears down the composition. On back-nav, the View's grid/list scrolls to that item if it lives in the freshly-loaded set.
- Applied to `library-movies`, `library-tvshows`, `library-music` — the same three screens PR #310 touched.
- Music carries one `selectedItemId` across Artists and Albums tabs. The View reads it from the active tab's list only; the inactive list won't match it (so won't scroll), which is the desired behavior.

## Design choice — option (b) best-effort

Per the issue's design wrinkle: if the user had paginated past page 1 and selected an item past the freshly-loaded `PAGE_SIZE`, the Model has no way to know that without eager pagination, and the scroll won't reach it. This PR ships **option (b)** — if the selected id is in the loaded set, scroll; otherwise leave the grid at the top. Option (a) (eager-paginate until selected id appears) was deferred to keep scope focused; it can be a follow-up if (b) proves insufficient in practice.

The `LaunchedEffect` also skips the scroll if the user has already scrolled away (`firstVisibleItemIndex != 0 || firstVisibleItemScrollOffset != 0`), so subsequent `loadMore` appends don't snap them back to the top.

## Test plan

- [x] `:screens:library-movies:jvmTest`, `:screens:library-tvshows:jvmTest`, `:screens:library-music:jvmTest` all pass.
- [x] `./check --lite` passes.
- [ ] Manual on Desktop / Android: open Movies, scroll a bit, tap a movie, navigate back — confirm the grid is centered on the selected movie (not snapped to top). Repeat for TV Shows; for Music try both the Artists list and the Albums grid (and switch tabs to confirm cross-tab selection doesn't fire spurious scrolls).
- [ ] Negative case: paginate Movies past PAGE_SIZE (50), select an item ~75, navigate back — confirm best-effort behaviour (grid stays at top because item isn't in the loaded set; no error). Document this in a follow-up if it's worth chasing eager-pagination.