### PR TITLE
#278 Audio Player Phase 1: shared queue, shuffle, repeat, service interface

### DIFF
--- a/services/player/public/build.gradle.kts
+++ b/services/player/public/build.gradle.kts
@@ -20,5 +20,11 @@ kotlin {
 
       api(libs.kotlinx.coroutines.core)
     }
+
+    commonTest.dependencies {
+      implementation(kotlin("test"))
+
+      implementation(libs.test.kotest.assertions.core)
+    }
   }
 }

--- a/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/AudioPlaybackState.kt
+++ b/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/AudioPlaybackState.kt
@@ -1,0 +1,128 @@
+package com.eygraber.jellyfin.services.player
+
+/**
+ * Snapshot of the audio player at a point in time. Emitted via
+ * [AudioPlayerService.audioState] so UI layers can render Now Playing,
+ * mini-players, queue lists, and platform-native controls from a single source.
+ *
+ * The [queue] is always the canonical (un-shuffled) ordering of tracks. When
+ * [shuffleMode] is [ShuffleMode.On] the active playback order is described by
+ * [shuffleOrder], a permutation of indices into [queue]; otherwise the playback
+ * order matches the queue itself. UI components that just need to render a list
+ * should use [queue] and the `shuffleOrder` is primarily an implementation
+ * detail surfaced for testability and platform integrations that need to render
+ * the upcoming-tracks list.
+ *
+ * @property queue Canonical, un-shuffled list of tracks the player is working with.
+ * @property currentIndex Index into [queue] of the currently-loaded track, or `-1`
+ *   when the queue is empty.
+ * @property shuffleOrder Permutation of `0..queue.lastIndex` describing the active
+ *   playback order when [shuffleMode] is [ShuffleMode.On]. When shuffle is off
+ *   this is empty.
+ * @property shuffleMode Whether shuffle is currently engaged.
+ * @property repeatMode Whether the queue should repeat on completion.
+ * @property isPlaying `true` when audio is actively playing (not paused, not
+ *   buffering-paused, not idle).
+ * @property isBuffering `true` when the player is loading data and cannot yet play.
+ * @property hasError `true` when the underlying player reported an error. UI should
+ *   surface [errorMessage] when present.
+ * @property errorMessage Human-readable error description, or `null` when there is
+ *   no active error.
+ * @property currentPositionMs Playback position within the current track.
+ * @property durationMs Reported duration of the current track. `0L` until the player
+ *   has determined the duration.
+ * @property bufferedPositionMs How much of the current track has been buffered ahead
+ *   of the playhead.
+ */
+data class AudioPlaybackState(
+  val queue: List<AudioTrack> = emptyList(),
+  val currentIndex: Int = -1,
+  val shuffleOrder: List<Int> = emptyList(),
+  val shuffleMode: ShuffleMode = ShuffleMode.Off,
+  val repeatMode: RepeatMode = RepeatMode.Off,
+  val isPlaying: Boolean = false,
+  val isBuffering: Boolean = false,
+  val hasError: Boolean = false,
+  val errorMessage: String? = null,
+  val currentPositionMs: Long = 0L,
+  val durationMs: Long = 0L,
+  val bufferedPositionMs: Long = 0L,
+) {
+  /** Convenience: the currently-loaded track, or `null` when the queue is empty. */
+  val currentTrack: AudioTrack? get() = queue.getOrNull(currentIndex)
+
+  /**
+   * Progress through the current track as a fraction in `[0f, 1f]`. Returns `0f`
+   * when [durationMs] is unknown (avoids divide-by-zero noise in UI).
+   */
+  val progress: Float
+    get() = if(durationMs > 0L) {
+      (currentPositionMs.toFloat() / durationMs.toFloat()).coerceIn(minimumValue = 0f, maximumValue = 1f)
+    }
+    else {
+      0f
+    }
+
+  companion object {
+    /** Empty / idle state — used as the initial value of [AudioPlayerService.audioState]. */
+    val Idle = AudioPlaybackState()
+  }
+}
+
+/**
+ * A track the audio player can play.
+ *
+ * Kept deliberately minimal — anything richer (album art URLs, codec details) lives
+ * on the data-layer model. The service only needs an identifier, where to fetch the
+ * audio bytes, and the metadata that drives system media controls (Now Playing on
+ * iOS, MediaSession on Android, etc.).
+ *
+ * @property id Stable identifier for the track (typically the Jellyfin item ID).
+ *   Used to correlate progress reporting and to detect "is this the same track
+ *   already loaded?" across queue updates.
+ * @property streamUrl URL the player should pull audio bytes from. Resolved by the
+ *   data layer (direct play / direct stream / transcode) before the track reaches
+ *   this service.
+ * @property title Track title, surfaced in system media controls.
+ * @property artist Primary artist string, surfaced in system media controls.
+ * @property album Album name. May be `null` for non-album items (singles, podcast
+ *   episodes).
+ * @property artworkUrl URL to album/track artwork for system media controls.
+ * @property durationMs Known duration of the track from server metadata. Optional
+ *   because the player will report its own duration once it's loaded the source.
+ * @property playSessionId Server-assigned session ID for progress reporting. Empty
+ *   string when the track wasn't created from a server playback-info call (e.g.
+ *   tests).
+ */
+data class AudioTrack(
+  val id: String,
+  val streamUrl: String,
+  val title: String,
+  val artist: String,
+  val album: String? = null,
+  val artworkUrl: String? = null,
+  val durationMs: Long? = null,
+  val playSessionId: String = "",
+)
+
+/** Whether playback should pull from a shuffled order or the canonical queue order. */
+enum class ShuffleMode {
+  Off,
+  On,
+}
+
+/**
+ * How the player should behave at the boundaries of the queue.
+ */
+enum class RepeatMode {
+  /** Stop on the last track; "previous" at the start of the queue is a no-op. */
+  Off,
+
+  /** When a track ends, restart it. Manual skip ([AudioPlayerService.next] /
+   *  [AudioPlayerService.previous]) still moves to the adjacent track.
+   */
+  One,
+
+  /** Wrap from the last track back to the first (and vice-versa for "previous"). */
+  All,
+}

--- a/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/AudioPlayerService.kt
+++ b/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/AudioPlayerService.kt
@@ -1,0 +1,121 @@
+package com.eygraber.jellyfin.services.player
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-agnostic audio player service.
+ *
+ * Coordinates a queue of [AudioTrack]s with shuffle and repeat semantics, exposing
+ * a reactive [audioState] for UI observation. Per-platform implementations (Android
+ * [`MediaSession`][androidx.media3.session.MediaSession], iOS `AVAudioSession`,
+ * Desktop tray, Web Media Session API) wire this interface to native audio output
+ * and system media controls.
+ *
+ * Unlike [VideoPlayerService] which deals with a single stream at a time, the audio
+ * player owns the queue: callers push a list of tracks and the service handles
+ * intra-queue navigation ([next] / [previous]) along with [shuffleMode] and
+ * [repeatMode] state.
+ *
+ * Lifecycle is tied to the application (not a screen) so background playback can
+ * survive UI navigation. Platform implementations are expected to be application-scoped
+ * singletons.
+ */
+interface AudioPlayerService {
+  /**
+   * Reactive snapshot of the player's current state — current track, queue,
+   * playback position, shuffle/repeat mode, etc.
+   */
+  val audioState: StateFlow<AudioPlaybackState>
+
+  /**
+   * Replaces the queue and starts playback at [startIndex] of the given list.
+   *
+   * If the new queue is empty the player is released. The current shuffle / repeat
+   * settings are preserved across queue changes.
+   *
+   * @param tracks Ordered list of tracks to play.
+   * @param startIndex Index into [tracks] to begin playback from. Coerced to the
+   *   valid range; a value outside `0..tracks.lastIndex` falls back to `0`.
+   * @param startPositionMs Position within the starting track to begin from.
+   */
+  fun setQueue(
+    tracks: List<AudioTrack>,
+    startIndex: Int = 0,
+    startPositionMs: Long = 0L,
+  )
+
+  /**
+   * Appends [tracks] to the end of the queue. Does not change the currently-playing
+   * track. No-op if the queue is empty (use [setQueue] to start a new queue).
+   */
+  fun addToQueue(tracks: List<AudioTrack>)
+
+  /** Starts or resumes playback of the current track. */
+  fun play()
+
+  /** Pauses playback without releasing resources. */
+  fun pause()
+
+  /**
+   * Toggles between [play] and [pause] based on the current state. A no-op when no
+   * queue is loaded.
+   */
+  fun playPause()
+
+  /**
+   * Seeks within the current track.
+   *
+   * @param positionMs Target position in milliseconds, coerced into the track's
+   *   `[0, durationMs]` range by the implementation.
+   */
+  fun seekTo(positionMs: Long)
+
+  /**
+   * Advances to the next track per the current [shuffleMode] and [repeatMode].
+   *
+   * Behavior:
+   *  - In [RepeatMode.One] this still advances (replicating the standard "skip
+   *    overrides repeat-one" UX), and the next track plays under repeat-one once it
+   *    starts.
+   *  - In [ShuffleMode.On] the next track is the next entry in the active shuffled
+   *    order.
+   *  - At the end of the queue: under [RepeatMode.All] wraps to the first track;
+   *    under [RepeatMode.Off] the player stops on the last track.
+   */
+  fun next()
+
+  /**
+   * Moves to the previous track. If the current position is past
+   * [PREVIOUS_RESTART_THRESHOLD_MS] within the track this seeks back to `0L`
+   * instead (matching standard media-player UX).
+   *
+   * At the start of the queue: under [RepeatMode.All] wraps to the last track;
+   * under [RepeatMode.Off] this is a no-op.
+   */
+  fun previous()
+
+  /** Jumps directly to [index] in the current queue. Out-of-range indexes are ignored. */
+  fun skipTo(index: Int)
+
+  /**
+   * Updates the shuffle mode. Switching to [ShuffleMode.On] generates a fresh
+   * shuffled order pinned around the current track; switching to [ShuffleMode.Off]
+   * restores the original queue order with the current track preserved.
+   */
+  fun setShuffleMode(mode: ShuffleMode)
+
+  /** Updates the repeat mode. */
+  fun setRepeatMode(mode: RepeatMode)
+
+  /** Releases all underlying resources and clears the queue. */
+  fun release()
+
+  companion object {
+    /**
+     * Pressing "previous" while past this point in the current track restarts the
+     * track instead of skipping back. Mirrors typical music-player UX so that a
+     * mis-press doesn't lose the listener's place.
+     */
+    const val PREVIOUS_RESTART_THRESHOLD_MS: Long = 3_000L
+  }
+}

--- a/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/AudioQueue.kt
+++ b/services/player/public/src/commonMain/kotlin/com/eygraber/jellyfin/services/player/AudioQueue.kt
@@ -1,0 +1,295 @@
+package com.eygraber.jellyfin.services.player
+
+import kotlin.random.Random
+
+/**
+ * Pure, immutable representation of an audio queue plus its shuffle / repeat state.
+ *
+ * Lives in `services/player/public` so the per-platform [AudioPlayerService]
+ * implementations can share the queue arithmetic (next, previous, shuffle order
+ * generation, repeat handling) without each re-deriving it. Every state-changing
+ * method returns a new [AudioQueue] — never mutates `this` — so the implementations
+ * can hand the result to a `MutableStateFlow` and trust that observers see a clean
+ * before/after pair.
+ *
+ * The queue tracks two orderings:
+ *  - [tracks] is the canonical ordering as inserted by the caller.
+ *  - [shuffleOrder] is a permutation of `tracks` indices used when [shuffleMode]
+ *    is [ShuffleMode.On]. When shuffle is off this is empty (so `==` comparison
+ *    of two un-shuffled queues stays cheap and correct).
+ *
+ * "Position" everywhere refers to an index into [tracks] (the canonical position),
+ * not into [shuffleOrder]. This is what UI surfaces care about ("track 5 of 12") and
+ * what the data layer correlates with item IDs.
+ *
+ * @property tracks Canonical list of tracks.
+ * @property currentIndex Index into [tracks] of the currently active track, or `-1`
+ *   when the queue is empty.
+ * @property shuffleMode Whether [shuffleOrder] should be consulted for next/previous.
+ * @property repeatMode Boundary behavior when reaching the start or end of the queue.
+ * @property shuffleOrder When [shuffleMode] is on: a permutation of
+ *   `tracks.indices` describing playback order. When off: empty.
+ */
+data class AudioQueue(
+  val tracks: List<AudioTrack> = emptyList(),
+  val currentIndex: Int = -1,
+  val shuffleMode: ShuffleMode = ShuffleMode.Off,
+  val repeatMode: RepeatMode = RepeatMode.Off,
+  val shuffleOrder: List<Int> = emptyList(),
+) {
+  init {
+    require(tracks.isEmpty() || currentIndex in tracks.indices) {
+      "currentIndex $currentIndex out of bounds for queue of size ${tracks.size}"
+    }
+    require(shuffleMode == ShuffleMode.Off || shuffleOrder.size == tracks.size) {
+      "shuffleOrder must be a permutation of tracks indices when shuffle is on"
+    }
+  }
+
+  /** The currently active track, or `null` when the queue is empty. */
+  val currentTrack: AudioTrack? get() = tracks.getOrNull(currentIndex)
+
+  /** `true` when there are no tracks loaded. */
+  val isEmpty: Boolean get() = tracks.isEmpty()
+
+  /**
+   * Replaces the queue with [newTracks] and positions the cursor at [startIndex].
+   *
+   * Out-of-range start indexes coerce to `0` (matching the [AudioPlayerService.setQueue]
+   * contract). Shuffle order is regenerated when [shuffleMode] is on so the new
+   * track set has a fresh permutation.
+   *
+   * @param random Source of randomness used when re-generating the shuffle order.
+   *   Tests pass a seeded [Random] so shuffle behavior is reproducible.
+   */
+  fun replace(
+    newTracks: List<AudioTrack>,
+    startIndex: Int = 0,
+    random: Random = Random.Default,
+  ): AudioQueue {
+    if(newTracks.isEmpty()) {
+      return AudioQueue(
+        shuffleMode = shuffleMode,
+        repeatMode = repeatMode,
+      )
+    }
+
+    val safeStart = if(startIndex in newTracks.indices) startIndex else 0
+    val newShuffleOrder = when(shuffleMode) {
+      ShuffleMode.Off -> emptyList()
+      ShuffleMode.On -> generateShuffleOrder(
+        size = newTracks.size,
+        pinnedIndex = safeStart,
+        random = random,
+      )
+    }
+
+    return AudioQueue(
+      tracks = newTracks,
+      currentIndex = safeStart,
+      shuffleMode = shuffleMode,
+      repeatMode = repeatMode,
+      shuffleOrder = newShuffleOrder,
+    )
+  }
+
+  /**
+   * Appends [moreTracks] to the end of the queue.
+   *
+   * The current track is preserved. When shuffle is on the appended tracks are
+   * spliced into a random position *after* the current shuffle position so they
+   * play in the upcoming portion of the queue but in a randomized order.
+   */
+  fun append(moreTracks: List<AudioTrack>, random: Random = Random.Default): AudioQueue {
+    if(moreTracks.isEmpty()) return this
+    if(tracks.isEmpty()) return replace(newTracks = moreTracks, random = random)
+
+    val newTracks = tracks + moreTracks
+    val newShuffleOrder = when(shuffleMode) {
+      ShuffleMode.Off -> emptyList()
+      ShuffleMode.On -> {
+        val appendedIndices = (tracks.size until newTracks.size).toList().shuffled(random)
+        // Splice the new (already-shuffled) appended indices in after the current
+        // shuffle position so they play in the upcoming portion of the shuffle order.
+        val currentShufflePos = shuffleOrder.indexOf(currentIndex)
+          .coerceAtLeast(minimumValue = 0)
+        shuffleOrder.subList(fromIndex = 0, toIndex = currentShufflePos + 1) +
+          appendedIndices +
+          shuffleOrder.subList(fromIndex = currentShufflePos + 1, toIndex = shuffleOrder.size)
+      }
+    }
+
+    return copy(
+      tracks = newTracks,
+      shuffleOrder = newShuffleOrder,
+    )
+  }
+
+  /**
+   * Computes the queue after a "next" press.
+   *
+   * - Empty queue → unchanged.
+   * - Last track + [RepeatMode.Off] → `null` to signal the player should stop.
+   *   ([RepeatMode.One] also stops on manual next-at-end since "skip overrides
+   *   repeat-one" and there's no next track to skip to.)
+   * - Last track + [RepeatMode.All] → wraps to the first track (or the first entry
+   *   in [shuffleOrder] when shuffled).
+   * - Otherwise → advances by one step in the active order.
+   *
+   * Returns `null` to signal "playback should end" — the caller is expected to
+   * release the underlying player and surface a stopped state.
+   */
+  fun next(): AudioQueue? {
+    if(isEmpty) return this
+
+    val nextIndex = nextIndexOrNull() ?: return null
+    return copy(currentIndex = nextIndex)
+  }
+
+  /**
+   * Computes the queue after a "previous" press.
+   *
+   * - Empty queue → unchanged.
+   * - First track + [RepeatMode.Off] → unchanged (caller may still seek to 0L).
+   * - First track + [RepeatMode.All] → wraps to the last track.
+   * - Otherwise → moves back one step in the active order.
+   *
+   * Note: this method only handles the index transition. The "if past the restart
+   * threshold, just seek to 0L" behavior described on
+   * [AudioPlayerService.PREVIOUS_RESTART_THRESHOLD_MS] is the player implementation's
+   * responsibility — it knows the current playback position.
+   */
+  fun previous(): AudioQueue {
+    if(isEmpty) return this
+
+    val previousIndex = previousIndexOrNull() ?: return this
+    return copy(currentIndex = previousIndex)
+  }
+
+  /**
+   * Computes the queue after a track ends naturally (player reached the end of
+   * the source).
+   *
+   * Differs from [next] only in [RepeatMode.One]: a natural end under repeat-one
+   * stays on the same track so the player can replay it.
+   *
+   * Returns `null` when the queue is exhausted ([RepeatMode.Off] at the last track).
+   */
+  fun onTrackEnded(): AudioQueue? = when(repeatMode) {
+    RepeatMode.One -> this
+    RepeatMode.Off, RepeatMode.All -> next()
+  }
+
+  /**
+   * Jumps directly to [index] in the canonical [tracks] list. Out-of-range indexes
+   * leave the queue unchanged.
+   */
+  fun skipTo(index: Int): AudioQueue {
+    if(index !in tracks.indices) return this
+    return copy(currentIndex = index)
+  }
+
+  /**
+   * Toggles shuffle on/off.
+   *
+   * Turning shuffle on generates a fresh permutation pinned around the current
+   * track (so playback continues from where the listener was). Turning shuffle
+   * off restores canonical order with the current track preserved (so the listener
+   * doesn't suddenly hear a different song).
+   *
+   * Calling with the current mode is a no-op (avoids re-generating shuffle order
+   * unnecessarily, which would change the upcoming-tracks list).
+   */
+  fun setShuffleMode(mode: ShuffleMode, random: Random = Random.Default): AudioQueue {
+    if(mode == shuffleMode) return this
+
+    val newShuffleOrder = when(mode) {
+      ShuffleMode.Off -> emptyList()
+      ShuffleMode.On -> if(tracks.isEmpty()) {
+        emptyList()
+      }
+      else {
+        generateShuffleOrder(size = tracks.size, pinnedIndex = currentIndex, random = random)
+      }
+    }
+
+    return copy(
+      shuffleMode = mode,
+      shuffleOrder = newShuffleOrder,
+    )
+  }
+
+  /** Updates the repeat mode. The queue contents are unchanged. */
+  fun setRepeatMode(mode: RepeatMode): AudioQueue = copy(repeatMode = mode)
+
+  /**
+   * Computes the next index per the current [shuffleMode] and [repeatMode], or
+   * `null` when the queue is exhausted.
+   *
+   * Visible for testing — production code should call [next] (which preserves
+   * the rest of the queue state).
+   */
+  internal fun nextIndexOrNull(): Int? {
+    if(isEmpty) return null
+    val order = activeOrder()
+    val pos = order.indexOf(currentIndex)
+    if(pos < 0) return null
+
+    return when {
+      pos < order.lastIndex -> order[pos + 1]
+      repeatMode == RepeatMode.All -> order.first()
+      else -> null
+    }
+  }
+
+  /**
+   * Computes the previous index per the current [shuffleMode] and [repeatMode],
+   * or `null` when "previous" should be a no-op.
+   */
+  internal fun previousIndexOrNull(): Int? {
+    if(isEmpty) return null
+    val order = activeOrder()
+    val pos = order.indexOf(currentIndex)
+    if(pos < 0) return null
+
+    return when {
+      pos > 0 -> order[pos - 1]
+      repeatMode == RepeatMode.All -> order.last()
+      else -> null
+    }
+  }
+
+  /**
+   * Returns the active playback order — the shuffled permutation when shuffle is
+   * on, or a 0..lastIndex sequence when it's off.
+   */
+  private fun activeOrder(): List<Int> = when(shuffleMode) {
+    ShuffleMode.On -> shuffleOrder
+    ShuffleMode.Off -> tracks.indices.toList()
+  }
+
+  companion object {
+    /**
+     * Generates a shuffle permutation of `0 until size` with [pinnedIndex] placed
+     * at the front, so playback can continue immediately from the current track
+     * after enabling shuffle.
+     *
+     * Behavior:
+     *  - `size <= 1` → returns `[0]` (or empty when `size == 0`); a one-track queue
+     *    has nothing to shuffle.
+     *  - Otherwise → the first element is `pinnedIndex` and the remainder is a
+     *    random permutation of the other indices.
+     */
+    fun generateShuffleOrder(
+      size: Int,
+      pinnedIndex: Int,
+      random: Random = Random.Default,
+    ): List<Int> {
+      if(size <= 0) return emptyList()
+      if(size == 1) return listOf(0)
+      val safePinned = pinnedIndex.coerceIn(minimumValue = 0, maximumValue = size - 1)
+      val others = (0 until size).filter { it != safePinned }.shuffled(random)
+      return listOf(safePinned) + others
+    }
+  }
+}

--- a/services/player/public/src/commonTest/kotlin/com/eygraber/jellyfin/services/player/AudioQueueTest.kt
+++ b/services/player/public/src/commonTest/kotlin/com/eygraber/jellyfin/services/player/AudioQueueTest.kt
@@ -1,0 +1,313 @@
+package com.eygraber.jellyfin.services.player
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+import kotlin.test.Test
+
+class AudioQueueTest {
+  @Test
+  fun empty_queue_has_no_current_track() {
+    val queue = AudioQueue()
+    queue.currentTrack.shouldBeNull()
+    queue.isEmpty shouldBe true
+  }
+
+  @Test
+  fun replace_with_empty_clears_queue_but_preserves_modes() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.All)
+      .replace(newTracks = tracks(3))
+
+    val cleared = queue.replace(newTracks = emptyList())
+
+    cleared.tracks shouldBe emptyList()
+    cleared.currentIndex shouldBe -1
+    cleared.repeatMode shouldBe RepeatMode.All
+  }
+
+  @Test
+  fun replace_coerces_out_of_range_start_index_to_zero() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = 99)
+    queue.currentIndex shouldBe 0
+  }
+
+  @Test
+  fun replace_negative_start_index_coerces_to_zero() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = -5)
+    queue.currentIndex shouldBe 0
+  }
+
+  // -- next / previous: linear order, RepeatMode.Off ----------------------
+
+  @Test
+  fun next_advances_through_queue() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = 0)
+
+    val second = queue.next().shouldNotBeNull()
+    second.currentIndex shouldBe 1
+
+    val third = second.next().shouldNotBeNull()
+    third.currentIndex shouldBe 2
+  }
+
+  @Test
+  fun next_at_end_with_repeat_off_returns_null() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = 2)
+    queue.next().shouldBeNull()
+  }
+
+  @Test
+  fun previous_at_start_with_repeat_off_is_no_op() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = 0)
+    val result = queue.previous()
+    result.currentIndex shouldBe 0
+  }
+
+  @Test
+  fun previous_moves_back_through_queue() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = 2)
+    queue.previous().currentIndex shouldBe 1
+    queue.previous().previous().currentIndex shouldBe 0
+  }
+
+  // -- RepeatMode.All wraps -----------------------------------------------
+
+  @Test
+  fun next_at_end_with_repeat_all_wraps_to_first() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.All)
+      .replace(newTracks = tracks(3), startIndex = 2)
+
+    val wrapped = queue.next().shouldNotBeNull()
+    wrapped.currentIndex shouldBe 0
+  }
+
+  @Test
+  fun previous_at_start_with_repeat_all_wraps_to_last() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.All)
+      .replace(newTracks = tracks(3), startIndex = 0)
+
+    queue.previous().currentIndex shouldBe 2
+  }
+
+  // -- RepeatMode.One -----------------------------------------------------
+
+  @Test
+  fun on_track_ended_with_repeat_one_stays_on_same_track() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.One)
+      .replace(newTracks = tracks(3), startIndex = 1)
+
+    val ended = queue.onTrackEnded().shouldNotBeNull()
+    ended.currentIndex shouldBe 1
+  }
+
+  @Test
+  fun manual_next_under_repeat_one_still_advances() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.One)
+      .replace(newTracks = tracks(3), startIndex = 1)
+
+    val next = queue.next().shouldNotBeNull()
+    next.currentIndex shouldBe 2
+  }
+
+  @Test
+  fun manual_next_at_end_under_repeat_one_stops() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.One)
+      .replace(newTracks = tracks(3), startIndex = 2)
+
+    queue.next().shouldBeNull()
+  }
+
+  @Test
+  fun on_track_ended_under_repeat_all_wraps() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.All)
+      .replace(newTracks = tracks(3), startIndex = 2)
+
+    val wrapped = queue.onTrackEnded().shouldNotBeNull()
+    wrapped.currentIndex shouldBe 0
+  }
+
+  @Test
+  fun on_track_ended_under_repeat_off_at_end_is_null() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = 2)
+    queue.onTrackEnded().shouldBeNull()
+  }
+
+  // -- skipTo -------------------------------------------------------------
+
+  @Test
+  fun skip_to_valid_index() {
+    val queue = AudioQueue().replace(newTracks = tracks(5), startIndex = 0)
+    queue.skipTo(3).currentIndex shouldBe 3
+  }
+
+  @Test
+  fun skip_to_out_of_range_is_no_op() {
+    val queue = AudioQueue().replace(newTracks = tracks(3), startIndex = 1)
+    queue.skipTo(99).currentIndex shouldBe 1
+    queue.skipTo(-1).currentIndex shouldBe 1
+  }
+
+  // -- shuffle ------------------------------------------------------------
+
+  @Test
+  fun setting_shuffle_off_when_already_off_is_no_op() {
+    val queue = AudioQueue().replace(newTracks = tracks(3))
+    queue.setShuffleMode(ShuffleMode.Off) shouldBe queue
+  }
+
+  @Test
+  fun enabling_shuffle_pins_current_index_first() {
+    val queue = AudioQueue().replace(newTracks = tracks(5), startIndex = 2)
+
+    val shuffled = queue.setShuffleMode(ShuffleMode.On, random = Random(seed = 42L))
+
+    shuffled.shuffleMode shouldBe ShuffleMode.On
+    shuffled.shuffleOrder.first() shouldBe 2
+    shuffled.shuffleOrder.size shouldBe 5
+    shuffled.shuffleOrder shouldContainExactlyInAnyOrder listOf(0, 1, 2, 3, 4)
+  }
+
+  @Test
+  fun shuffle_order_is_a_permutation_of_track_indices() {
+    val queue = AudioQueue()
+      .replace(newTracks = tracks(10), startIndex = 0)
+      .setShuffleMode(ShuffleMode.On, random = Random(seed = 1L))
+
+    queue.shuffleOrder shouldContainExactlyInAnyOrder (0..9).toList()
+  }
+
+  @Test
+  fun next_under_shuffle_follows_shuffle_order() {
+    val queue = AudioQueue()
+      .replace(newTracks = tracks(4), startIndex = 0)
+      .setShuffleMode(ShuffleMode.On, random = Random(seed = 7L))
+
+    // Verify that next/previous traverses the shuffle order, not the canonical 0,1,2,3.
+    val expectedOrder = queue.shuffleOrder
+    var current = queue
+    val visited = mutableListOf(current.currentIndex)
+    while(true) {
+      current = current.next() ?: break
+      visited += current.currentIndex
+    }
+    visited shouldContainExactly expectedOrder
+  }
+
+  @Test
+  fun next_at_end_of_shuffle_order_with_repeat_all_wraps_to_shuffle_first() {
+    val queue = AudioQueue()
+      .setRepeatMode(RepeatMode.All)
+      .replace(newTracks = tracks(4), startIndex = 0)
+      .setShuffleMode(ShuffleMode.On, random = Random(seed = 7L))
+      .copy(currentIndex = queue4LastShuffleIndex(seed = 7L))
+
+    val next = queue.next().shouldNotBeNull()
+    next.currentIndex shouldBe queue.shuffleOrder.first()
+  }
+
+  @Test
+  fun disabling_shuffle_keeps_current_track() {
+    val queue = AudioQueue()
+      .replace(newTracks = tracks(5), startIndex = 0)
+      .setShuffleMode(ShuffleMode.On, random = Random(seed = 99L))
+
+    // Move forward in shuffle order so currentIndex differs from the canonical 0.
+    val advanced = queue.next().shouldNotBeNull()
+    val keptCurrentIndex = advanced.currentIndex
+
+    val unshuffled = advanced.setShuffleMode(ShuffleMode.Off)
+
+    unshuffled.shuffleMode shouldBe ShuffleMode.Off
+    unshuffled.shuffleOrder shouldBe emptyList()
+    unshuffled.currentIndex shouldBe keptCurrentIndex
+  }
+
+  @Test
+  fun shuffle_with_single_track_yields_zero() {
+    val order = AudioQueue.generateShuffleOrder(size = 1, pinnedIndex = 0)
+    order shouldBe listOf(0)
+  }
+
+  @Test
+  fun shuffle_with_zero_size_yields_empty() {
+    val order = AudioQueue.generateShuffleOrder(size = 0, pinnedIndex = 0)
+    order shouldBe emptyList()
+  }
+
+  @Test
+  fun shuffle_pinned_index_out_of_range_coerces() {
+    val order = AudioQueue.generateShuffleOrder(
+      size = 3,
+      pinnedIndex = 99,
+      random = Random(seed = 0L),
+    )
+    order.first() shouldBe 2
+    order shouldContainExactlyInAnyOrder listOf(0, 1, 2)
+  }
+
+  // -- append -------------------------------------------------------------
+
+  @Test
+  fun append_to_empty_queue_starts_a_new_queue() {
+    val queue = AudioQueue().append(moreTracks = tracks(3))
+    queue.tracks.size shouldBe 3
+    queue.currentIndex shouldBe 0
+  }
+
+  @Test
+  fun append_keeps_current_track_intact() {
+    val queue = AudioQueue()
+      .replace(newTracks = tracks(3), startIndex = 1)
+      .append(moreTracks = tracks(prefix = "extra-", count = 2))
+
+    queue.tracks.size shouldBe 5
+    queue.currentIndex shouldBe 1
+    queue.currentTrack?.id shouldBe "track-1"
+  }
+
+  @Test
+  fun append_under_shuffle_inserts_into_upcoming_portion() {
+    val queue = AudioQueue()
+      .replace(newTracks = tracks(3), startIndex = 0)
+      .setShuffleMode(ShuffleMode.On, random = Random(seed = 5L))
+      .append(moreTracks = tracks(prefix = "extra-", count = 2), random = Random(seed = 5L))
+
+    // After append the shuffle order must still be a permutation of all track indices.
+    queue.shuffleOrder shouldContainExactlyInAnyOrder (0..4).toList()
+    // Current shuffle position must be unchanged - the appended tracks go after it.
+    queue.shuffleOrder.indexOf(queue.currentIndex) shouldBe 0
+  }
+
+  // -- helpers ------------------------------------------------------------
+
+  private fun tracks(count: Int, prefix: String = "track-"): List<AudioTrack> =
+    List(count) { i ->
+      AudioTrack(
+        id = "$prefix$i",
+        streamUrl = "https://example.test/$prefix$i.mp3",
+        title = "Title $i",
+        artist = "Artist",
+      )
+    }
+
+  /**
+   * Helper for [next_at_end_of_shuffle_order_with_repeat_all_wraps_to_shuffle_first].
+   * Mirrors how the shuffled order is generated to find the *last* shuffled index for
+   * a 4-track queue with the given seed, so the test can position the cursor there
+   * without relying on knowledge of the random sequence.
+   */
+  private fun queue4LastShuffleIndex(seed: Long): Int {
+    val order = AudioQueue.generateShuffleOrder(size = 4, pinnedIndex = 0, random = Random(seed = seed))
+    return order.last()
+  }
+}


### PR DESCRIPTION
Closes #278

## Summary

- Defines the cross-platform `AudioPlayerService` interface that the per-platform implementations (Android `MediaSession`, iOS Control Center, Desktop tray, Web Media Session API) will build on in subsequent phases of #60.
- Adds `AudioQueue`, a pure immutable model for queue + shuffle order + repeat semantics so platform impls don't each re-derive the queue arithmetic. Kept in `services/player/public` so the impls can reuse it.
- Adds `AudioPlaybackState` as the snapshot consumers observe via `AudioPlayerService.audioState` (queue, current index, shuffle/repeat mode, position, buffering, error).
- 29 unit tests cover queue replacement / append, next/previous traversal, `RepeatMode.{Off, One, All}` boundary behavior, manual-skip-vs-natural-end semantics under repeat-one, shuffle order generation pinned around the current track, append splicing in shuffled mode, and edge cases (empty queue, single track, out-of-range indices).

## Out of scope (handled in later phases)

- Per-platform `AudioPlayerService` implementations — phases #279 (Android), #280 (iOS), #281 (Desktop), #282 (Web)
- Audio-only UI mode, Now Playing screen, mini-player — phase #283

## Test plan

- [x] `./gradlew :services:player:public:jvmTest` — 29 tests pass
- [x] `./gradlew :services:player:public:detektAll` — clean
- [x] `./gradlew assembleDebug` — builds across all targets
- [x] `./check --lite` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)